### PR TITLE
fix: 월간뷰 항목 과다 시 오버플로우 방지 + 더보기 토글

### DIFF
--- a/app/static/schedule/css/style.css
+++ b/app/static/schedule/css/style.css
@@ -984,6 +984,12 @@ body {
   vertical-align: top;
   padding: 2px;
   height: 150px;
+  max-height: 150px;
+  overflow: hidden;
+}
+.month-day-cell.expanded {
+  max-height: none;
+  overflow: visible;
 }
 .month-table tbody td.empty-cell { background: #fafafa; }
 .month-table tbody td.today-cell { background: #e8f4fd; }

--- a/app/static/schedule/js/schedule-app.js
+++ b/app/static/schedule/js/schedule-app.js
@@ -29,6 +29,7 @@
     App.initWeekendToggle();    // 주말 표시 토글
     App.initShiftSchedule();    // 일정 일괄 이동
     App.initAddButtons();       // 태스크/블록 추가 버튼
+    App.initMonthBlockLimit();  // 월간뷰 초과 블록 숨김
     App.initMonthMoreToggle();  // 월간뷰 더보기 토글
     App.initQueueMultiSelect(); // 큐 Shift+클릭 다중 선택
   }

--- a/app/static/schedule/js/schedule-features.js
+++ b/app/static/schedule/js/schedule-features.js
@@ -331,11 +331,35 @@
   App.initTaskHoverLink = initTaskHoverLink;
 
   // =====================================================================
-  // 월간뷰 "더보기" 토글
+  // 월간뷰 블록 수 제한 + "더보기" 토글
   // =====================================================================
+  var MAX_MONTH_ITEMS = 3;
+
+  /**
+   * 월간뷰 각 셀에서 MAX_MONTH_ITEMS 초과 블록을 숨기고
+   * '+N개 더' 토글 링크를 동적으로 삽입한다.
+   */
+  function initMonthBlockLimit() {
+    document.querySelectorAll('.month-day-cell').forEach(function (cell) {
+      // 이미 처리된 셀은 건너뜀
+      if (cell.querySelector('.month-more-toggle')) return;
+
+      var blocks = cell.querySelectorAll('.month-block-item');
+      if (blocks.length <= MAX_MONTH_ITEMS) return;
+
+      for (var i = MAX_MONTH_ITEMS; i < blocks.length; i++) {
+        blocks[i].classList.add('month-block-hidden');
+      }
+
+      var toggle = document.createElement('span');
+      toggle.className = 'month-more-toggle';
+      toggle.textContent = '+' + (blocks.length - MAX_MONTH_ITEMS) + '개 더';
+      cell.appendChild(toggle);
+    });
+  }
+
   /**
    * 월간뷰 셀에서 숨겨진 블록의 '더보기/접기' 토글을 초기화한다.
-   * 셀에 블록이 많으면 일부를 숨기고 '+N개 더' 링크로 표시한다.
    */
   function initMonthMoreToggle() {
     document.querySelectorAll('.month-more-toggle').forEach(function (el) {
@@ -347,7 +371,6 @@
         if (expanded) {
           el.textContent = '접기';
         } else {
-          // 숨겨진 블록 수를 세어 표시
           var hidden = cell.querySelectorAll('.month-block-hidden').length;
           el.textContent = '+' + hidden + '개 더';
         }
@@ -420,6 +443,7 @@
   App.initWeekendToggle = initWeekendToggle;
   App.initShiftSchedule = initShiftSchedule;
   App.initAddButtons = initAddButtons;
+  App.initMonthBlockLimit = initMonthBlockLimit;
   App.initMonthMoreToggle = initMonthMoreToggle;
   App.initQueueMultiSelect = initQueueMultiSelect;
   App.getSelectedQueueItems = getSelectedQueueItems;


### PR DESCRIPTION
## Summary

- 월간뷰 셀에 항목이 많을 때 날짜 행이 밀려나는 오버플로우 버그 수정
- 셀당 최대 3개 블록만 표시, 초과분은 숨기고 `+N개 더` 토글 링크 삽입
- 토글 클릭 시 해당 셀만 펼쳐지고, 다시 클릭하면 접힘

## Test plan

- [ ] 하루에 4개 이상 블록이 있는 월간뷰 확인 → 3개만 보이고 `+N개 더` 표시
- [ ] `+N개 더` 클릭 → 전체 블록 표시, `접기` 버튼으로 변경
- [ ] `접기` 클릭 → 다시 3개만 표시
- [ ] 블록이 3개 이하인 셀은 토글 없이 정상 표시 확인
- [ ] 월간 달력 전체 레이아웃 오버플로우 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)