### PR TITLE
fix(execution): segments KeyError 방지

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -16,7 +16,7 @@ def _execution_response(ex):
     return {
         'id': ex['id'],
         'status': ex['status'],
-        'elapsed_seconds': ExecutionRepository.compute_elapsed_seconds(ex['segments']),
+        'elapsed_seconds': ExecutionRepository.compute_elapsed_seconds(ex.get('segments', [])),
         'total_count': ex.get('total_count', 0),
         'fail_count': ex.get('fail_count', 0),
         'pass_count': ex.get('pass_count', 0),


### PR DESCRIPTION
## Summary
- `_execution_response`에서 `ex['segments']` 직접 접근 시 `KeyError` 발생하는 버그 수정
- `ex.get('segments', [])` 로 변경하여 `segments` 키 없는 데이터도 안전하게 처리
- closes #36

## Test plan
- [ ] `pytest tests/test_execution.py` — 17 passed 확인
- [ ] execution 페이지에서 에러 없이 목록 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)