### PR TITLE
feat(execution): 시험 실행 모달 개선

### DIFF
--- a/app/features/execution/models/execution.py
+++ b/app/features/execution/models/execution.py
@@ -69,6 +69,7 @@ class ExecutionRepository:
             'total_count': total_count,
             'fail_count': 0,
             'pass_count': 0,
+            'comment': '',
             'created_at': now,
             'completed_at': None,
         }
@@ -120,6 +121,10 @@ class ExecutionRepository:
         )
 
     @classmethod
+    def update_comment(cls, execution_id, comment):
+        return cls._patch(execution_id, comment=comment)
+
+    @classmethod
     def reset(cls, execution_id):
         return cls._patch(
             execution_id,
@@ -127,5 +132,6 @@ class ExecutionRepository:
             segments=[],
             fail_count=0,
             pass_count=0,
+            comment='',
             completed_at=None,
         )

--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -20,6 +20,7 @@ def _execution_response(ex):
         'total_count': ex.get('total_count', 0),
         'fail_count': ex.get('fail_count', 0),
         'pass_count': ex.get('pass_count', 0),
+        'comment': ex.get('comment', ''),
     }
 
 
@@ -134,6 +135,19 @@ def complete():
     if ex is None:
         return jsonify({'error': 'not found or invalid state'}), 404
     return jsonify(ex)
+
+
+@api_bp.route('/comment', methods=['PUT'])
+def update_comment():
+    body = request.get_json(silent=True) or {}
+    execution_id = body.get('execution_id', '').strip()
+    comment = body.get('comment', '')
+    if not execution_id:
+        return jsonify({'error': 'execution_id required'}), 400
+    ex = ExecutionRepository.update_comment(execution_id, comment)
+    if ex is None:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify({'ok': True})
 
 
 @api_bp.route('/reset', methods=['POST'])

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -126,6 +126,47 @@ function stopLocalTimer() {
   _localTimerStart = null;
 }
 
+function _infoHtml(item) {
+  const ex = item.execution;
+  const rows = [
+    ['TC', escHtml(item.identifier_id)],
+    ['식별자명', escHtml(item.identifier_name)],
+    item.doc_name ? ['문서', escHtml(item.doc_name)] : null,
+    item.location_name ? ['장소', escHtml(item.location_name)] : null,
+    item.scheduled_date ? ['예정일', escHtml(item.scheduled_date)] : null,
+    ex ? ['총 건수', `${ex.total_count}건`] : null,
+  ].filter(Boolean);
+  return `<div class="bg-light rounded p-2 mb-3 small">
+    <div class="row g-1">${rows.map(([k, v]) =>
+      `<div class="col-4 text-muted">${k}</div><div class="col-8">${v}</div>`
+    ).join('')}</div>
+  </div>`;
+}
+
+function _commentHtml(ex) {
+  if (!ex) return '';
+  return `<div class="mt-3">
+    <label class="form-label small text-muted mb-1">코멘트</label>
+    <textarea id="comment-input" class="form-control form-control-sm" rows="2"
+      placeholder="시험 관련 코멘트 입력...">${escHtml(ex.comment || '')}</textarea>
+  </div>`;
+}
+
+function _attachCommentHandler() {
+  const ta = document.getElementById('comment-input');
+  if (!ta) return;
+  ta.addEventListener('blur', async () => {
+    if (!_currentItem?.execution?.id) return;
+    try {
+      await apiFetch('/execution/api/comment', 'PUT', {
+        execution_id: _currentItem.execution.id,
+        comment: ta.value,
+      });
+      _currentItem.execution.comment = ta.value;
+    } catch { /* 저장 실패 시 무시 */ }
+  });
+}
+
 function renderModalBody(item) {
   const ex = item.execution;
   const status = ex ? ex.status : 'pending';
@@ -133,6 +174,7 @@ function renderModalBody(item) {
 
   if (status === 'pending' || !ex) {
     body.innerHTML = `
+      ${_infoHtml(item)}
       <div class="text-center py-3">
         <button class="btn btn-success btn-lg" onclick="doStart()">
           <i class="bi bi-play-fill"></i> 시험시작
@@ -148,16 +190,19 @@ function renderModalBody(item) {
 
   if (status === 'completed') {
     body.innerHTML = `
+      ${_infoHtml(item)}
       <div class="text-center mb-3">
         <span class="fs-5">✅ 완료 &nbsp; 총 ${formatElapsed(elapsed)}</span>
       </div>
       <div class="text-center mb-3">
         PASS: <strong>${pass}</strong> &nbsp;&nbsp; FAIL: <strong>${fail}</strong> &nbsp;&nbsp; (총 ${total}건)
       </div>
-      <div class="d-flex justify-content-between">
+      ${_commentHtml(ex)}
+      <div class="d-flex justify-content-between mt-3">
         <button class="btn btn-outline-secondary btn-sm" onclick="doReset()">재시험</button>
         <button class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
       </div>`;
+    _attachCommentHandler();
     return;
   }
 
@@ -169,26 +214,28 @@ function renderModalBody(item) {
        <button class="btn btn-success ms-3" onclick="doResume()"><i class="bi bi-play-fill"></i> 재시작</button>`;
 
   body.innerHTML = `
+    ${_infoHtml(item)}
     <div class="d-flex align-items-center mb-3">
       ${status === 'in_progress' ? '⏱' : '⏸'} &nbsp; ${timerHtml}
     </div>
     <div class="mb-3">
-      <label class="form-label">총 시험: <strong>${total}건</strong></label>
       <div class="d-flex align-items-center gap-2">
         <label class="form-label mb-0">FAIL</label>
         <input type="number" id="fail-input" class="form-control form-control-sm" style="width:80px"
                min="0" max="${total}" value="${fail}" oninput="updatePass()">
         <span class="text-muted">→ PASS:</span>
         <strong id="pass-display">${pass}</strong>
-        <span class="text-muted">(자동계산)</span>
+        <span class="text-muted">/ ${total}건</span>
       </div>
     </div>
-    <div class="d-flex justify-content-between">
+    ${_commentHtml(ex)}
+    <div class="d-flex justify-content-between mt-3">
       <button class="btn btn-outline-secondary btn-sm" onclick="doReset()">재시험</button>
       <button class="btn btn-primary" onclick="doComplete()">
         <i class="bi bi-check-lg"></i> 시험완료
       </button>
     </div>`;
+  _attachCommentHandler();
 }
 
 function updatePass() {

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -47,7 +47,8 @@
 </div>
 
 <!-- 실행 모달 -->
-<div class="modal fade" id="execModal" tabindex="-1" aria-labelledby="execModalTitle" aria-hidden="true">
+<div class="modal fade" id="execModal" tabindex="-1" aria-labelledby="execModalTitle" aria-hidden="true"
+     data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
## Summary
- 시험시작/시험중/시험완료를 단일 모달에서 상태별로 렌더링 (기존 구조 유지 + UI 개선)
- 모달 상단에 TC ID, 식별자명, 문서, 장소, 예정일, 총 건수 등 개별 정보 표시
- `data-bs-backdrop="static"` 추가 — 모달 바깥 클릭 시 닫히지 않음
- 코멘트 텍스트 필드 추가 (시험 진행 중/완료 상태에서 표시, blur 시 자동 저장)
- `ExecutionRepository.update_comment()` 메서드 및 `PUT /execution/api/comment` 엔드포인트 추가
- closes #38

## Test plan
- [ ] `pytest tests/test_execution.py` — 17 passed 확인
- [ ] 시험 실행 목록에서 더블클릭 → 모달 열림, 개별 정보 표시 확인
- [ ] 모달 바깥 클릭 시 닫히지 않음 확인
- [ ] 코멘트 입력 후 포커스 이동 시 자동 저장 확인
- [ ] 시험시작 → 진행 → 완료 상태 전환 시 코멘트 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)