### PR TITLE
feat(providers): REST API 프로바이더 추가

### DIFF
--- a/app/features/schedule/providers/__init__.py
+++ b/app/features/schedule/providers/__init__.py
@@ -23,4 +23,7 @@ def get_provider():
     provider_type = os.environ.get('PROVIDER_TYPE', 'json_file')
     if provider_type == 'json_file':
         return JsonFileProvider()
+    if provider_type == 'rest_api':
+        from app.features.schedule.providers.rest_api import RestApiProvider
+        return RestApiProvider()
     raise ValueError(f'Unknown provider type: {provider_type}')

--- a/app/features/schedule/providers/rest_api.py
+++ b/app/features/schedule/providers/rest_api.py
@@ -1,0 +1,26 @@
+import os
+import requests
+from app.features.schedule.providers.base import BaseProvider
+
+
+class RestApiProvider(BaseProvider):
+
+    def __init__(self):
+        self.base_url = os.environ.get('API_BASE_URL', '').rstrip('/')
+        self.api_key = os.environ.get('API_KEY', '')
+        self.headers = {'Authorization': f'Bearer {self.api_key}'} if self.api_key else {}
+
+    def get_versions(self):
+        resp = requests.get(f'{self.base_url}/versions', headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_test_data(self, version_id):
+        resp = requests.get(f'{self.base_url}/procedures/{version_id}', headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_test_data_all(self):
+        resp = requests.get(f'{self.base_url}/procedures', headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
## Summary
- `RestApiProvider` 클래스 신규 구현 (`app/features/schedule/providers/rest_api.py`)
- 환경변수 기반 설정: `PROVIDER_TYPE=rest_api`, `API_BASE_URL`, `API_KEY`
- `providers/__init__.py` 팩토리에 `rest_api` 타입 등록

## 사용법
```bash
PROVIDER_TYPE=rest_api \
API_BASE_URL=https://your-api.com \
API_KEY=your-key \
python3 -m flask run --port 5000
```

## Test plan
- [ ] `PROVIDER_TYPE=rest_api` 환경변수로 서버 실행
- [ ] 시험 항목 목록 페이지에서 동기화 버튼 클릭
- [ ] `/api/sync/reset-and-sync` 응답 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)