### PR TITLE
fix(sync): 동기화 버튼 onclick 제거 및 프로바이더 기본값 변경

### DIFF
--- a/app/features/schedule/providers/__init__.py
+++ b/app/features/schedule/providers/__init__.py
@@ -20,7 +20,7 @@ def get_provider():
     Raises:
         ValueError: 알 수 없는 프로바이더 타입이 지정된 경우.
     """
-    provider_type = os.environ.get('PROVIDER_TYPE', 'json_file')
+    provider_type = os.environ.get('PROVIDER_TYPE', 'rest_api')
     if provider_type == 'json_file':
         return JsonFileProvider()
     if provider_type == 'rest_api':

--- a/app/templates/schedule/tasks/list.html
+++ b/app/templates/schedule/tasks/list.html
@@ -17,7 +17,7 @@
       {% endif %}
     </div>
     <div class="d-flex gap-2">
-      <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-sync" onclick="runSync()">
+      <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-sync">
         <i class="bi bi-arrow-repeat"></i> 동기화
       </button>
       <a href="{{ url_for('tasks.task_new') }}" class="btn btn-primary btn-sm">
@@ -195,11 +195,9 @@
 
 {% block scripts_sub %}
 <script>
-var syncModal = new bootstrap.Modal(document.getElementById('syncConfirmModal'));
-
-function runSync() {
-  syncModal.show();
-}
+document.getElementById('btn-sync').addEventListener('click', function() {
+  new bootstrap.Modal(document.getElementById('syncConfirmModal')).show();
+});
 
 document.getElementById('btn-sync-confirm').addEventListener('click', function() {
   var confirmBtn = this;
@@ -219,7 +217,7 @@ document.getElementById('btn-sync-confirm').addEventListener('click', function()
       var msgs = [];
       msgs.push('버전: +' + v.added + ' / 갱신 ' + v.updated + ' / 비활성 ' + v.deactivated);
       msgs.push('항목: +' + t.added + ' / 갱신 ' + t.updated + ' / 취소 ' + t.cancelled);
-      syncModal.hide();
+      bootstrap.Modal.getInstance(document.getElementById('syncConfirmModal')).hide();
       alert('동기화 완료\n' + msgs.join('\n'));
       location.reload();
     })


### PR DESCRIPTION
## Summary
- 동기화 버튼 `onclick="runSync()"` 인라인 핸들러를 스크립트 내 이벤트 리스너로 교체 (`runSync is not defined` 오류 수정)
- `PROVIDER_TYPE` 환경변수 기본값을 `json_file` → `rest_api`로 변경

## Test plan
- [ ] 시험 항목 목록 페이지에서 동기화 버튼 클릭 시 확인 모달 표시 확인
- [ ] 초기화 후 동기화 버튼 클릭 시 API 호출 및 결과 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)