### PR TITLE
fix(execution): 시험실행 페이지 UX 이슈 처리 (#42~#49)

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -74,6 +74,7 @@ def execution_list():
                 'identifier_name': identifier.get('name', ''),
                 'task_id': task['id'],
                 'doc_name': task.get('doc_name', ''),
+                'assignee_names': task.get('assignee_names', []),
                 'location_id': loc_id,
                 'location_name': loc_name,
                 'scheduled_date': scheduled_date,

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -1,14 +1,6 @@
 'use strict';
 
-// 현재 열린 모달의 실행 데이터
 let _currentItem = null;
-// 타이머 인터벌 ID
-let _timerInterval = null;
-// 마지막 서버 elapsed_seconds + 로컬 시작 시각
-let _localTimerBase = 0;
-let _localTimerStart = null;
-
-// ── 유틸 ──────────────────────────────────────────────────────────────────
 
 function formatElapsed(seconds) {
   const h = Math.floor(seconds / 3600);
@@ -44,13 +36,13 @@ async function loadList() {
   if (loc) params.set('location', loc);
 
   const tbody = document.getElementById('exec-tbody');
-  tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">로딩 중...</td></tr>';
+  tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted">로딩 중...</td></tr>';
 
   try {
     const items = await apiFetch('/execution/api/list?' + params.toString());
     renderTable(items);
   } catch {
-    tbody.innerHTML = '<tr><td colspan="6" class="text-center text-danger">로드 실패</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">로드 실패</td></tr>';
   }
 }
 
@@ -58,35 +50,33 @@ function statusBadge(item) {
   const ex = item.execution;
   if (!ex) return '<span class="badge bg-secondary">○ 대기</span>';
   switch (ex.status) {
-    case 'in_progress':
-      return `<span class="badge bg-primary">🔵 진행 ${formatElapsed(ex.elapsed_seconds)}</span>`;
-    case 'paused':
-      return `<span class="badge bg-warning text-dark">⏸ 일시정지 ${formatElapsed(ex.elapsed_seconds)}</span>`;
-    case 'completed':
-      return `<span class="badge bg-success">✅ 완료</span>`;
-    case 'pending':
-      return '<span class="badge bg-secondary">○ 대기</span>';
-    default:
-      return '<span class="badge bg-secondary">-</span>';
+    case 'in_progress': return '<span class="badge bg-primary">🔵 진행 중</span>';
+    case 'paused':      return '<span class="badge bg-warning text-dark">⏸ 일시정지</span>';
+    case 'completed':   return '<span class="badge bg-success">✅ 완료</span>';
+    case 'pending':     return '<span class="badge bg-secondary">○ 대기</span>';
+    default:            return '<span class="badge bg-secondary">-</span>';
   }
 }
 
 function renderTable(items) {
   const tbody = document.getElementById('exec-tbody');
   if (!items.length) {
-    tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted py-4">항목 없음</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-4">항목 없음</td></tr>';
     return;
   }
-  tbody.innerHTML = items.map(item => `
+  tbody.innerHTML = items.map(item => {
+    const assignee = (item.assignee_names || []).join(', ') || '-';
+    return `
     <tr data-id="${item.identifier_id}" data-item='${JSON.stringify(item).replace(/'/g, "&#39;")}' style="cursor:pointer">
+      <td class="text-muted small">${escHtml(item.doc_name || '-')}</td>
       <td><code>${escHtml(item.identifier_id)}</code></td>
       <td>${escHtml(item.identifier_name)}</td>
-      <td class="text-muted small">${escHtml(item.doc_name)}</td>
-      <td class="text-muted small">${item.location_name ? escHtml(item.location_name) : '-'}</td>
+      <td class="text-muted small">${escHtml(assignee)}</td>
+      <td class="text-muted small">${item.location_name || '-'}</td>
       <td class="text-muted small">${item.scheduled_date || '-'}</td>
       <td>${statusBadge(item)}</td>
-    </tr>
-  `).join('');
+    </tr>`;
+  }).join('');
 
   tbody.querySelectorAll('tr').forEach(tr => {
     tr.addEventListener('dblclick', () => {
@@ -104,36 +94,18 @@ function openModal(item) {
     `${item.identifier_id} — ${item.identifier_name}`;
   renderModalBody(item);
   new bootstrap.Modal(document.getElementById('execModal')).show();
-  startLocalTimer(item);
-}
-
-function startLocalTimer(item) {
-  stopLocalTimer();
-  const ex = item.execution;
-  if (!ex || ex.status !== 'in_progress') return;
-  _localTimerBase = ex.elapsed_seconds;
-  _localTimerStart = Date.now();
-  _timerInterval = setInterval(() => {
-    const elapsed = _localTimerBase + Math.floor((Date.now() - _localTimerStart) / 1000);
-    const el = document.getElementById('timer-display');
-    if (el) el.textContent = formatElapsed(elapsed);
-  }, 1000);
-}
-
-function stopLocalTimer() {
-  if (_timerInterval) { clearInterval(_timerInterval); _timerInterval = null; }
-  _localTimerBase = 0;
-  _localTimerStart = null;
 }
 
 function _infoHtml(item) {
   const ex = item.execution;
+  const assignee = (item.assignee_names || []).join(', ') || '-';
   const rows = [
     ['TC', escHtml(item.identifier_id)],
     ['식별자명', escHtml(item.identifier_name)],
-    item.doc_name ? ['문서', escHtml(item.doc_name)] : null,
-    item.location_name ? ['장소', escHtml(item.location_name)] : null,
-    item.scheduled_date ? ['예정일', escHtml(item.scheduled_date)] : null,
+    ['문서', escHtml(item.doc_name || '-')],
+    ['담당자', escHtml(assignee)],
+    ['장소', escHtml(item.location_name || '-')],
+    ['예정일', escHtml(item.scheduled_date || '-')],
     ex ? ['총 건수', `${ex.total_count}건`] : null,
   ].filter(Boolean);
   return `<div class="bg-light rounded p-2 mb-3 small">
@@ -143,19 +115,10 @@ function _infoHtml(item) {
   </div>`;
 }
 
-function _commentHtml(ex) {
-  if (!ex) return '';
-  return `<div class="mt-3">
-    <label class="form-label small text-muted mb-1">코멘트</label>
-    <textarea id="comment-input" class="form-control form-control-sm" rows="2"
-      placeholder="시험 관련 코멘트 입력...">${escHtml(ex.comment || '')}</textarea>
-  </div>`;
-}
-
 function _attachCommentHandler() {
   const ta = document.getElementById('comment-input');
   if (!ta) return;
-  ta.addEventListener('blur', async () => {
+  const save = async () => {
     if (!_currentItem?.execution?.id) return;
     try {
       await apiFetch('/execution/api/comment', 'PUT', {
@@ -164,7 +127,9 @@ function _attachCommentHandler() {
       });
       _currentItem.execution.comment = ta.value;
     } catch { /* 저장 실패 시 무시 */ }
-  });
+  };
+  ta.addEventListener('blur', save);
+  ta.addEventListener('change', save);
 }
 
 function renderModalBody(item) {
@@ -172,74 +137,87 @@ function renderModalBody(item) {
   const status = ex ? ex.status : 'pending';
   const body = document.getElementById('execModalBody');
 
-  if (status === 'pending' || !ex) {
-    body.innerHTML = `
-      ${_infoHtml(item)}
-      <div class="text-center py-3">
-        <button class="btn btn-success btn-lg" onclick="doStart()">
-          <i class="bi bi-play-fill"></i> 시험시작
-        </button>
-      </div>`;
-    return;
+  // 상태별 주요 액션 버튼
+  let actionHtml;
+  if (status === 'pending') {
+    actionHtml = `<button class="btn btn-success btn-lg" onclick="doStart()">
+      <i class="bi bi-play-fill"></i> 시험시작
+    </button>`;
+  } else if (status === 'in_progress') {
+    actionHtml = `<button class="btn btn-warning" onclick="doPause()">
+      <i class="bi bi-pause-fill"></i> 일시정지
+    </button>`;
+  } else if (status === 'paused') {
+    actionHtml = `<button class="btn btn-success" onclick="doResume()">
+      <i class="bi bi-play-fill"></i> 재시작
+    </button>`;
+  } else {
+    actionHtml = `<span class="fs-5">✅ 완료 &nbsp; 총 ${formatElapsed(ex.elapsed_seconds)}</span>`;
   }
 
-  const elapsed = ex.elapsed_seconds;
-  const total = ex.total_count;
-  const fail = ex.fail_count;
-  const pass = ex.pass_count;
-
-  if (status === 'completed') {
-    body.innerHTML = `
-      ${_infoHtml(item)}
-      <div class="text-center mb-3">
-        <span class="fs-5">✅ 완료 &nbsp; 총 ${formatElapsed(elapsed)}</span>
-      </div>
-      <div class="text-center mb-3">
-        PASS: <strong>${pass}</strong> &nbsp;&nbsp; FAIL: <strong>${fail}</strong> &nbsp;&nbsp; (총 ${total}건)
-      </div>
-      ${_commentHtml(ex)}
-      <div class="d-flex justify-content-between mt-3">
-        <button class="btn btn-outline-secondary btn-sm" onclick="doReset()">재시험</button>
-        <button class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
-      </div>`;
-    _attachCommentHandler();
-    return;
-  }
-
-  // in_progress or paused
-  const timerHtml = status === 'in_progress'
-    ? `<span id="timer-display" class="fs-3 font-monospace">${formatElapsed(elapsed)}</span>
-       <button class="btn btn-warning ms-3" onclick="doPause()"><i class="bi bi-pause-fill"></i> 일시정지</button>`
-    : `<span id="timer-display" class="fs-3 font-monospace text-muted">${formatElapsed(elapsed)}</span>
-       <button class="btn btn-success ms-3" onclick="doResume()"><i class="bi bi-play-fill"></i> 재시작</button>`;
-
-  body.innerHTML = `
-    ${_infoHtml(item)}
-    <div class="d-flex align-items-center mb-3">
-      ${status === 'in_progress' ? '⏱' : '⏸'} &nbsp; ${timerHtml}
-    </div>
+  // FAIL/PASS 입력 (진행중/일시정지) 또는 결과 요약 (완료)
+  let failPassHtml = '';
+  if (ex && (status === 'in_progress' || status === 'paused')) {
+    failPassHtml = `
     <div class="mb-3">
       <div class="d-flex align-items-center gap-2">
         <label class="form-label mb-0">FAIL</label>
         <input type="number" id="fail-input" class="form-control form-control-sm" style="width:80px"
-               min="0" max="${total}" value="${fail}" oninput="updatePass()">
+               min="0" max="${ex.total_count}" value="${ex.fail_count}" oninput="updatePass()">
         <span class="text-muted">→ PASS:</span>
-        <strong id="pass-display">${pass}</strong>
-        <span class="text-muted">/ ${total}건</span>
+        <strong id="pass-display">${ex.pass_count}</strong>
+        <span class="text-muted">/ ${ex.total_count}건</span>
       </div>
-    </div>
-    ${_commentHtml(ex)}
+    </div>`;
+  } else if (ex && status === 'completed') {
+    failPassHtml = `
+    <div class="mb-2 text-center small text-muted">
+      PASS: <strong>${ex.pass_count}</strong> &nbsp;&nbsp;
+      FAIL: <strong>${ex.fail_count}</strong> &nbsp;&nbsp;
+      (총 ${ex.total_count}건)
+    </div>`;
+  }
+
+  // 코멘트 (pending일 때는 비활성, 나머지는 활성)
+  const commentDisabled = !ex ? 'disabled' : '';
+  const commentValue = ex ? escHtml(ex.comment || '') : '';
+  const commentHtml = `
+  <div class="mb-3">
+    <label class="form-label small text-muted mb-1">코멘트</label>
+    <textarea id="comment-input" class="form-control form-control-sm" rows="2"
+      ${commentDisabled} placeholder="시험 관련 코멘트 입력...">${commentValue}</textarea>
+  </div>`;
+
+  // 하단 버튼
+  let footerHtml = '';
+  if (status === 'in_progress' || status === 'paused') {
+    footerHtml = `
     <div class="d-flex justify-content-between mt-3">
       <button class="btn btn-outline-secondary btn-sm" onclick="doReset()">재시험</button>
       <button class="btn btn-primary" onclick="doComplete()">
         <i class="bi bi-check-lg"></i> 시험완료
       </button>
     </div>`;
+  } else if (status === 'completed') {
+    footerHtml = `
+    <div class="d-flex justify-content-between mt-3">
+      <button class="btn btn-outline-secondary btn-sm" onclick="doReset()">재시험</button>
+      <button class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
+    </div>`;
+  }
+
+  body.innerHTML = `
+    ${_infoHtml(item)}
+    <div class="text-center mb-3">${actionHtml}</div>
+    ${failPassHtml}
+    ${commentHtml}
+    ${footerHtml}`;
+
   _attachCommentHandler();
 }
 
 function updatePass() {
-  if (!_currentItem || !_currentItem.execution) return;
+  if (!_currentItem?.execution) return;
   const total = _currentItem.execution.total_count;
   const fail = parseInt(document.getElementById('fail-input').value) || 0;
   document.getElementById('pass-display').textContent = Math.max(0, total - fail);
@@ -260,9 +238,9 @@ async function doStart() {
       total_count: ex.total_count,
       fail_count: 0,
       pass_count: 0,
+      comment: '',
     };
     renderModalBody(_currentItem);
-    startLocalTimer(_currentItem);
     await loadList();
   } catch { alert('시험시작 실패'); }
 }
@@ -272,9 +250,11 @@ async function doPause() {
     const ex = await apiFetch('/execution/api/pause', 'POST', {
       execution_id: _currentItem.execution.id,
     });
-    stopLocalTimer();
-    _currentItem.execution = { ..._currentItem.execution, status: 'paused',
-      elapsed_seconds: _computeElapsed(ex) };
+    _currentItem.execution = {
+      ..._currentItem.execution,
+      status: 'paused',
+      elapsed_seconds: _computeElapsed(ex),
+    };
     renderModalBody(_currentItem);
     await loadList();
   } catch { alert('일시정지 실패'); }
@@ -288,7 +268,6 @@ async function doResume() {
     _currentItem.execution.status = 'in_progress';
     _currentItem.execution.elapsed_seconds = _computeElapsed(ex);
     renderModalBody(_currentItem);
-    startLocalTimer(_currentItem);
     await loadList();
   } catch { alert('재시작 실패'); }
 }
@@ -301,7 +280,6 @@ async function doComplete() {
       execution_id: _currentItem.execution.id,
       fail_count: failCount,
     });
-    stopLocalTimer();
     _currentItem.execution = {
       ..._currentItem.execution,
       status: 'completed',
@@ -321,14 +299,12 @@ async function doReset() {
     await apiFetch('/execution/api/reset', 'POST', {
       execution_id: _currentItem.execution.id,
     });
-    stopLocalTimer();
     _currentItem.execution = null;
     renderModalBody(_currentItem);
     await loadList();
   } catch { alert('재시험 처리 실패'); }
 }
 
-// 서버 응답 ex(raw execution dict with segments)에서 elapsed_seconds 계산
 function _computeElapsed(ex) {
   let total = 0;
   const now = new Date();
@@ -343,8 +319,22 @@ function _computeElapsed(ex) {
 // ── 초기화 ────────────────────────────────────────────────────────────────
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('execModal').addEventListener('hidden.bs.modal', stopLocalTimer);
   document.getElementById('filter-date').addEventListener('change', loadList);
   document.getElementById('filter-location').addEventListener('change', loadList);
   loadList();
+
+  // 스페이스바 단축키: 시험시작 / 일시정지 / 재시작 (#49)
+  document.addEventListener('keydown', (e) => {
+    if (e.code !== 'Space') return;
+    const tag = document.activeElement.tagName;
+    if (tag === 'TEXTAREA' || tag === 'INPUT') return;
+    const modal = document.getElementById('execModal');
+    if (!modal.classList.contains('show')) return;
+    e.preventDefault();
+    if (!_currentItem) return;
+    const status = _currentItem.execution ? _currentItem.execution.status : 'pending';
+    if (status === 'pending') doStart();
+    else if (status === 'in_progress') doPause();
+    else if (status === 'paused') doResume();
+  });
 });

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -31,16 +31,17 @@
     <table class="table table-hover table-sm align-middle" id="exec-table">
       <thead class="table-light">
         <tr>
+          <th style="width:160px">문서</th>
           <th style="width:100px">TC</th>
           <th>식별자명</th>
-          <th style="width:140px">문서</th>
+          <th style="width:100px">담당자</th>
           <th style="width:90px">장소</th>
           <th style="width:90px">날짜</th>
           <th style="width:130px">상태</th>
         </tr>
       </thead>
       <tbody id="exec-tbody">
-        <tr><td colspan="6" class="text-center text-muted py-4">로딩 중...</td></tr>
+        <tr><td colspan="7" class="text-center text-muted py-4">로딩 중...</td></tr>
       </tbody>
     </table>
   </div>
@@ -48,8 +49,8 @@
 
 <!-- 실행 모달 -->
 <div class="modal fade" id="execModal" tabindex="-1" aria-labelledby="execModalTitle" aria-hidden="true"
-     data-bs-backdrop="static" data-bs-keyboard="false">
-  <div class="modal-dialog modal-dialog-centered">
+     data-bs-backdrop="static">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="execModalTitle">시험 실행</h5>

--- a/app/templates/schedule/tasks/list.html
+++ b/app/templates/schedule/tasks/list.html
@@ -17,7 +17,7 @@
       {% endif %}
     </div>
     <div class="d-flex gap-2">
-      <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-sync">
+      <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-sync" onclick="runSync()">
         <i class="bi bi-arrow-repeat"></i> 동기화
       </button>
       <a href="{{ url_for('tasks.task_new') }}" class="btn btn-primary btn-sm">
@@ -195,9 +195,9 @@
 
 {% block scripts_sub %}
 <script>
-document.getElementById('btn-sync').addEventListener('click', function() {
-  new bootstrap.Modal(document.getElementById('syncConfirmModal')).show();
-});
+function runSync() {
+  bootstrap.Modal.getOrCreateInstance(document.getElementById('syncConfirmModal')).show();
+}
 
 document.getElementById('btn-sync-confirm').addEventListener('click', function() {
   var confirmBtn = this;


### PR DESCRIPTION
## Summary

- 진행중/일시정지 배지 및 모달에서 경과 시간 표시 제거 (#42, #45)
- 장소/날짜가 비어있어도 모달 상세에 항상 표시 (#43)
- 완료 후 코멘트 blur + change 이벤트로 저장 보장 (#44)
- 모달 열릴 때부터 코멘트창 포함 모든 항목 표시 (pending 시 비활성) (#46)
- 문서 열을 첫 번째로 이동, 담당자 열 추가, 모달 크기 확대 (#47)
- `data-bs-keyboard="false"` 제거 → ESC 키로 모달 닫기 (#48)
- 스페이스바로 시험시작 / 일시정지 / 재시작 단축키 (입력창 포커스 시 제외) (#49)

## Test plan

- [ ] 시험 목록에서 문서 열이 첫 번째, 담당자 열이 표시되는지 확인
- [ ] 진행중/일시정지 배지에 시간이 뜨지 않는지 확인
- [ ] 모달 열었을 때 장소/날짜가 비어있어도 '-'로 표시되는지 확인
- [ ] pending 상태에서 코멘트창이 비활성으로 표시되는지 확인
- [ ] 시험 완료 후 코멘트 수정 가능한지 확인
- [ ] ESC 키로 모달이 닫히는지 확인
- [ ] 스페이스바로 시작/일시정지/재시작 동작하는지 확인
- [ ] 코멘트 입력창 포커스 시 스페이스바 단축키가 동작하지 않는지 확인

Closes #42, #43, #44, #45, #46, #47, #48, #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)