### PR TITLE
feat(execution): 테이블 정렬/검색/담당자 필터/소요시간 추가

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -75,6 +75,7 @@ def execution_list():
                 'task_id': task['id'],
                 'doc_name': task.get('doc_name', ''),
                 'assignee_names': task.get('assignee_names', []),
+                'estimated_minutes': identifier.get('estimated_minutes', 0),
                 'location_id': loc_id,
                 'location_name': loc_name,
                 'scheduled_date': scheduled_date,

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -1,12 +1,30 @@
 'use strict';
 
 let _currentItem = null;
+let _allItems = [];
+let _sortCol = null;   // 'date' | 'location' | 'status'
+let _sortDir = 'asc';
+let _activeAssignees = new Set();
+let _searchText = '';
+
+const STATUS_ORDER = { pending: 0, in_progress: 1, paused: 2, completed: 3 };
+
+// ── 유틸 ──────────────────────────────────────────────────────────────────
 
 function formatElapsed(seconds) {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   const s = seconds % 60;
   return [h, m, s].map(v => String(v).padStart(2, '0')).join(':');
+}
+
+function formatMinutes(mins) {
+  if (!mins) return '-';
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
 }
 
 function escHtml(s) {
@@ -36,15 +54,108 @@ async function loadList() {
   if (loc) params.set('location', loc);
 
   const tbody = document.getElementById('exec-tbody');
-  tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted">로딩 중...</td></tr>';
+  tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted">로딩 중...</td></tr>';
 
   try {
-    const items = await apiFetch('/execution/api/list?' + params.toString());
-    renderTable(items);
+    _allItems = await apiFetch('/execution/api/list?' + params.toString());
+    renderAssigneeBadges();
+    applyAndRender();
   } catch {
-    tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">로드 실패</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="text-center text-danger">로드 실패</td></tr>';
   }
 }
+
+// ── 담당자 뱃지 필터 ───────────────────────────────────────────────────────
+
+function renderAssigneeBadges() {
+  const container = document.getElementById('assignee-badges');
+  const allAssignees = new Set();
+  _allItems.forEach(item => (item.assignee_names || []).forEach(a => allAssignees.add(a)));
+
+  if (!allAssignees.size) { container.innerHTML = ''; return; }
+
+  container.innerHTML = [...allAssignees].sort().map(a => {
+    const active = _activeAssignees.has(a);
+    return `<span class="badge me-1 mb-1 ${active ? 'bg-primary' : 'bg-light text-dark border'}"
+      style="cursor:pointer;font-size:.8rem" onclick="toggleAssignee(${JSON.stringify(escHtml(a))})"
+      title="담당자 필터">${escHtml(a)}</span>`;
+  }).join('');
+}
+
+function toggleAssignee(name) {
+  // name은 escHtml 처리된 문자열이므로 원본 복원 불필요 (텍스트 비교용)
+  if (_activeAssignees.has(name)) _activeAssignees.delete(name);
+  else _activeAssignees.add(name);
+  renderAssigneeBadges();
+  applyAndRender();
+}
+
+// ── 정렬 ──────────────────────────────────────────────────────────────────
+
+function setSort(col) {
+  if (_sortCol === col) _sortDir = _sortDir === 'asc' ? 'desc' : 'asc';
+  else { _sortCol = col; _sortDir = 'asc'; }
+  updateSortIcons();
+  applyAndRender();
+}
+
+function updateSortIcons() {
+  document.querySelectorAll('th[data-sort]').forEach(th => {
+    const icon = th.querySelector('i');
+    if (th.dataset.sort === _sortCol) {
+      icon.className = `bi ms-1 ${_sortDir === 'asc' ? 'bi-sort-up' : 'bi-sort-down'}`;
+      icon.classList.remove('text-muted');
+    } else {
+      icon.className = 'bi bi-arrow-down-up ms-1 text-muted';
+    }
+  });
+}
+
+// ── 필터+정렬 적용 ────────────────────────────────────────────────────────
+
+function applyAndRender() {
+  let items = [..._allItems];
+
+  // 검색 필터
+  const q = _searchText.toLowerCase();
+  if (q) {
+    items = items.filter(item =>
+      item.identifier_id.toLowerCase().includes(q) ||
+      item.identifier_name.toLowerCase().includes(q)
+    );
+  }
+
+  // 담당자 필터
+  if (_activeAssignees.size > 0) {
+    items = items.filter(item =>
+      (item.assignee_names || []).some(a => _activeAssignees.has(escHtml(a)))
+    );
+  }
+
+  // 정렬
+  if (_sortCol) {
+    items.sort((a, b) => {
+      let va, vb;
+      if (_sortCol === 'date') {
+        va = a.scheduled_date || '';
+        vb = b.scheduled_date || '';
+      } else if (_sortCol === 'location') {
+        va = a.location_name || '';
+        vb = b.location_name || '';
+      } else if (_sortCol === 'status') {
+        va = STATUS_ORDER[a.execution?.status ?? 'pending'] ?? 0;
+        vb = STATUS_ORDER[b.execution?.status ?? 'pending'] ?? 0;
+      }
+      if (va < vb) return _sortDir === 'asc' ? -1 : 1;
+      if (va > vb) return _sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }
+
+  renderTable(items);
+}
+
+// ── 테이블 렌더링 ─────────────────────────────────────────────────────────
 
 function statusBadge(item) {
   const ex = item.execution;
@@ -61,7 +172,7 @@ function statusBadge(item) {
 function renderTable(items) {
   const tbody = document.getElementById('exec-tbody');
   if (!items.length) {
-    tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-4">항목 없음</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">항목 없음</td></tr>';
     return;
   }
   tbody.innerHTML = items.map(item => {
@@ -74,6 +185,7 @@ function renderTable(items) {
       <td class="text-muted small">${escHtml(assignee)}</td>
       <td class="text-muted small">${item.location_name || '-'}</td>
       <td class="text-muted small">${item.scheduled_date || '-'}</td>
+      <td class="text-muted small">${formatMinutes(item.estimated_minutes)}</td>
       <td>${statusBadge(item)}</td>
     </tr>`;
   }).join('');
@@ -100,12 +212,13 @@ function _infoHtml(item) {
   const ex = item.execution;
   const assignee = (item.assignee_names || []).join(', ') || '-';
   const rows = [
-    ['TC', escHtml(item.identifier_id)],
-    ['식별자명', escHtml(item.identifier_name)],
+    ['식별자', escHtml(item.identifier_id)],
+    ['시험항목', escHtml(item.identifier_name)],
     ['문서', escHtml(item.doc_name || '-')],
     ['담당자', escHtml(assignee)],
     ['장소', escHtml(item.location_name || '-')],
     ['예정일', escHtml(item.scheduled_date || '-')],
+    ['소요시간', formatMinutes(item.estimated_minutes)],
     ex ? ['총 건수', `${ex.total_count}건`] : null,
   ].filter(Boolean);
   return `<div class="bg-light rounded p-2 mb-3 small">
@@ -202,11 +315,11 @@ function renderModalBody(item) {
       <button class="btn btn-secondary btn-sm" data-bs-dismiss="modal">닫기</button>
     </div>`;
   } else {
-    const completeDisabled = !ex ? 'disabled' : '';
+    const disabledAttr = !ex ? 'disabled' : '';
     footerHtml = `
     <div class="d-flex justify-content-between mt-3">
-      <button class="btn btn-outline-secondary btn-sm" onclick="doReset()" ${!ex ? 'disabled' : ''}>재시험</button>
-      <button class="btn btn-primary" onclick="doComplete()" ${completeDisabled}>
+      <button class="btn btn-outline-secondary btn-sm" onclick="doReset()" ${disabledAttr}>재시험</button>
+      <button class="btn btn-primary" onclick="doComplete()" ${disabledAttr}>
         <i class="bi bi-check-lg"></i> 시험완료
       </button>
     </div>`;
@@ -327,9 +440,19 @@ function _computeElapsed(ex) {
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('filter-date').addEventListener('change', loadList);
   document.getElementById('filter-location').addEventListener('change', loadList);
+
+  document.getElementById('search-input').addEventListener('input', e => {
+    _searchText = e.target.value.trim();
+    applyAndRender();
+  });
+
+  document.querySelectorAll('th[data-sort]').forEach(th => {
+    th.addEventListener('click', () => setSort(th.dataset.sort));
+  });
+
   loadList();
 
-  // 스페이스바 단축키: 시험시작 / 일시정지 / 재시작 (#49)
+  // 스페이스바 단축키: 시험시작 / 일시정지 / 재시작
   document.addEventListener('keydown', (e) => {
     if (e.code !== 'Space') return;
     const tag = document.activeElement.tagName;

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -8,7 +8,7 @@
   </div>
 
   <!-- 필터 바 -->
-  <div class="d-flex gap-2 mb-3">
+  <div class="d-flex flex-wrap gap-2 mb-2">
     <select id="filter-date" class="form-select form-select-sm" style="width:auto">
       <option value="">전체 날짜</option>
       {% for d in dates %}
@@ -21,27 +21,39 @@
       <option value="{{ loc.id }}">{{ loc.name }}</option>
       {% endfor %}
     </select>
+    <input id="search-input" type="search" class="form-control form-control-sm" style="width:220px"
+           placeholder="식별자 / 시험항목 검색...">
     <button class="btn btn-sm btn-outline-secondary" onclick="loadList()">
       <i class="bi bi-arrow-clockwise"></i> 새로고침
     </button>
   </div>
+
+  <!-- 담당자 뱃지 필터 -->
+  <div id="assignee-badges" class="mb-2 d-flex flex-wrap gap-1"></div>
 
   <!-- 식별자 목록 테이블 -->
   <div class="table-responsive">
     <table class="table table-hover table-sm align-middle" id="exec-table">
       <thead class="table-light">
         <tr>
-          <th style="width:160px">문서</th>
-          <th style="width:100px">TC</th>
-          <th>식별자명</th>
+          <th style="width:150px">문서</th>
+          <th style="width:100px">식별자</th>
+          <th>시험항목</th>
           <th style="width:100px">담당자</th>
-          <th style="width:90px">장소</th>
-          <th style="width:90px">날짜</th>
-          <th style="width:130px">상태</th>
+          <th class="sortable" data-sort="location" style="width:90px;cursor:pointer">
+            장소 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
+          </th>
+          <th class="sortable" data-sort="date" style="width:90px;cursor:pointer">
+            날짜 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
+          </th>
+          <th style="width:80px">소요시간</th>
+          <th class="sortable" data-sort="status" style="width:120px;cursor:pointer">
+            상태 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
+          </th>
         </tr>
       </thead>
       <tbody id="exec-tbody">
-        <tr><td colspan="7" class="text-center text-muted py-4">로딩 중...</td></tr>
+        <tr><td colspan="8" class="text-center text-muted py-4">로딩 중...</td></tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
## Summary

- 열 이름 변경: TC → 식별자, 식별자명 → 시험항목
- 날짜 / 장소 / 상태 열 헤더 클릭으로 오름·내림차순 정렬
- 담당자 뱃지 클릭으로 다중 필터링 (OR 조건)
- 식별자 ID / 시험항목명 텍스트 검색
- 소요시간(estimated_minutes) 열 추가 — API 및 테이블, 모달 상세에 표시

## Test plan

- [ ] 날짜/장소/상태 헤더 클릭 시 정렬 아이콘 변경 및 정렬 동작 확인
- [ ] 담당자 뱃지 클릭 시 해당 담당자 항목만 표시되는지 확인
- [ ] 복수 담당자 뱃지 선택 시 OR 필터 동작 확인
- [ ] 검색창에 식별자 ID 입력 시 필터링 확인
- [ ] 검색창에 시험항목명 입력 시 필터링 확인
- [ ] 소요시간 열이 올바르게 표시되는지 확인 (분/시간 포맷)
- [ ] 모달 상세에서 소요시간 항목 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)