### PR TITLE
fix(execution): 이슈 #54 #55 #56 처리

### DIFF
--- a/app/features/execution/routes/views.py
+++ b/app/features/execution/routes/views.py
@@ -6,11 +6,18 @@ from app.features.schedule.models import schedule_block as block_repo
 views_bp = Blueprint('execution', __name__, url_prefix='/execution')
 
 
-@views_bp.route('/')
-def index():
+def _index_context():
     locations = loc_repo.get_all()
     blocks = block_repo.get_all()
     dates = sorted({b['date'] for b in blocks if b.get('date')})
-    return render_template('execution/index.html',
-                           locations=locations,
-                           dates=dates)
+    return dict(locations=locations, dates=dates)
+
+
+@views_bp.route('/')
+def index():
+    return render_template('execution/index.html', auto_open_id='', **_index_context())
+
+
+@views_bp.route('/<identifier_id>')
+def index_with_item(identifier_id):
+    return render_template('execution/index.html', auto_open_id=identifier_id, **_index_context())

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -6,6 +6,7 @@ let _sortCol = null;
 let _sortDir = 'asc';
 let _activeAssignees = new Set();
 let _searchText = '';
+let _pendingComment = '';  // 시험 시작 전 미리 입력된 코멘트
 
 // 타이머
 let _timerInterval = null;
@@ -293,14 +294,15 @@ function renderModalBody(item) {
     </div>`;
   }
 
-  // ── 코멘트 ────────────────────────────────────────────────────────────
+  // ── 코멘트 (모든 상태에서 편집 가능) ────────────────────────────────────
+  const commentValue = ex ? escHtml(ex.comment || '') : escHtml(_pendingComment);
   const commentHtml = `
   <div class="mb-3">
     <label class="form-label small text-muted mb-1">
       <i class="bi bi-chat-left-text me-1"></i>코멘트
     </label>
     <textarea id="comment-input" class="form-control form-control-sm" rows="2"
-      ${!ex ? 'disabled' : ''} placeholder="시험 관련 코멘트 입력…">${ex ? escHtml(ex.comment || '') : ''}</textarea>
+      placeholder="시험 관련 코멘트 입력…">${commentValue}</textarea>
   </div>`;
 
   // ── 하단 버튼 ─────────────────────────────────────────────────────────
@@ -334,7 +336,11 @@ function _attachCommentHandler() {
   const ta = document.getElementById('comment-input');
   if (!ta) return;
   const save = async () => {
-    if (!_currentItem?.execution?.id) return;
+    // pending: 로컬에만 저장, 시작 후 서버에 반영
+    if (!_currentItem?.execution?.id) {
+      _pendingComment = ta.value;
+      return;
+    }
     try {
       await apiFetch('/execution/api/comment', 'PUT', {
         execution_id: _currentItem.execution.id,
@@ -357,6 +363,10 @@ function updatePass() {
 // ── 액션 핸들러 ───────────────────────────────────────────────────────────
 
 async function doStart() {
+  // 시작 전 입력된 코멘트 캡처
+  const taComment = document.getElementById('comment-input');
+  if (taComment) _pendingComment = taComment.value;
+
   try {
     const ex = await apiFetch('/execution/api/start', 'POST', {
       identifier_id: _currentItem.identifier_id,
@@ -364,8 +374,16 @@ async function doStart() {
     });
     _currentItem.execution = {
       id: ex.id, status: ex.status, elapsed_seconds: 0,
-      total_count: ex.total_count, fail_count: 0, pass_count: 0, comment: '',
+      total_count: ex.total_count, fail_count: 0, pass_count: 0, comment: _pendingComment,
     };
+    // pending 코멘트가 있으면 서버에 저장
+    if (_pendingComment) {
+      await apiFetch('/execution/api/comment', 'PUT', {
+        execution_id: ex.id,
+        comment: _pendingComment,
+      });
+      _pendingComment = '';
+    }
     renderModalBody(_currentItem);
     startLocalTimer(_currentItem);
     await loadList();
@@ -435,7 +453,7 @@ function _computeElapsed(ex) {
 
 // ── 초기화 ────────────────────────────────────────────────────────────────
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('filter-date').addEventListener('change', loadList);
   document.getElementById('filter-location').addEventListener('change', loadList);
   document.getElementById('search-input').addEventListener('input', e => {
@@ -444,9 +462,18 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   document.querySelectorAll('th[data-sort]').forEach(th =>
     th.addEventListener('click', () => setSort(th.dataset.sort)));
-  document.getElementById('execModal').addEventListener('hidden.bs.modal', stopLocalTimer);
+  document.getElementById('execModal').addEventListener('hidden.bs.modal', () => {
+    stopLocalTimer();
+    _pendingComment = '';
+  });
 
-  loadList();
+  await loadList();
+
+  // URL로 직접 접근 시 해당 항목 모달 자동 오픈 (#55)
+  if (typeof AUTO_OPEN_ID === 'string' && AUTO_OPEN_ID) {
+    const target = _allItems.find(i => i.identifier_id === AUTO_OPEN_ID);
+    if (target) openModal(target);
+  }
 
   // 스페이스바 단축키
   document.addEventListener('keydown', e => {

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -61,7 +61,7 @@
 
 <!-- 실행 모달 -->
 <div class="modal fade" id="execModal" tabindex="-1" aria-labelledby="execModalTitle" aria-hidden="true"
-     data-bs-backdrop="static">
+     data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-header">
@@ -76,5 +76,6 @@
 {% endblock %}
 
 {% block scripts_sub %}
+<script>var AUTO_OPEN_ID = {{ auto_open_id | tojson }};</script>
 <script src="{{ url_for('static', filename='execution/js/execution-app.js') }}?v={{ cache_bust }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- **#54** ESC 키로 모달 닫기 비활성화 — X 버튼으로만 닫을 수 있도록 `data-bs-keyboard="false"` 복구
- **#55** `/execution/<identifier_id>` URL 직접 접근 지원 — Flask 라우트 추가, 페이지 로드 후 해당 항목 모달 자동 오픈
- **#56** 코멘트 모든 상태에서 편집 가능 — 대기 상태에서 미리 작성한 코멘트는 시험 시작 시 자동으로 서버에 저장

## Test plan

- [ ] 모달 열린 상태에서 ESC 눌러도 닫히지 않는지 확인
- [ ] X 버튼 클릭 시 정상 닫히는지 확인
- [ ] `/execution/TC-001` 직접 접근 시 목록 로드 후 해당 모달 자동 오픈 확인
- [ ] 존재하지 않는 ID로 접근 시 그냥 목록만 표시되는지 확인
- [ ] 대기 상태에서 코멘트 입력 후 시험시작 클릭 시 코멘트 저장 확인
- [ ] 진행 중/완료 상태에서 코멘트 수정 가능 확인

Closes #54, #55, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)