### PR TITLE
feat(execution): 시험실행 상세 페이지 전면 개편 (#59-#64)

### DIFF
--- a/app/features/execution/models/execution.py
+++ b/app/features/execution/models/execution.py
@@ -68,8 +68,10 @@ class ExecutionRepository:
             'segments': [{'start': now, 'end': None}],
             'total_count': total_count,
             'fail_count': 0,
+            'block_count': 0,
             'pass_count': 0,
             'comment': '',
+            'performer': '',
             'created_at': now,
             'completed_at': None,
         }
@@ -99,7 +101,7 @@ class ExecutionRepository:
         return cls._patch(execution_id, status='in_progress', segments=segments)
 
     @classmethod
-    def complete(cls, execution_id, fail_count):
+    def complete(cls, execution_id, fail_count, block_count=0):
         ex = cls.get_by_id(execution_id)
         if not ex:
             return None
@@ -110,12 +112,15 @@ class ExecutionRepository:
         if segments:
             segments[-1] = {**segments[-1], 'end': now}
         total_count = ex.get('total_count', 0)
-        pass_count = max(0, total_count - int(fail_count))
+        fail_count = int(fail_count)
+        block_count = int(block_count)
+        pass_count = max(0, total_count - fail_count - block_count)
         return cls._patch(
             execution_id,
             status='completed',
             segments=segments,
-            fail_count=int(fail_count),
+            fail_count=fail_count,
+            block_count=block_count,
             pass_count=pass_count,
             completed_at=now,
         )
@@ -125,13 +130,19 @@ class ExecutionRepository:
         return cls._patch(execution_id, comment=comment)
 
     @classmethod
+    def update_performer(cls, execution_id, performer):
+        return cls._patch(execution_id, performer=performer)
+
+    @classmethod
     def reset(cls, execution_id):
         return cls._patch(
             execution_id,
             status='pending',
             segments=[],
             fail_count=0,
+            block_count=0,
             pass_count=0,
             comment='',
+            performer='',
             completed_at=None,
         )

--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -19,8 +19,10 @@ def _execution_response(ex):
         'elapsed_seconds': ExecutionRepository.compute_elapsed_seconds(ex.get('segments', [])),
         'total_count': ex.get('total_count', 0),
         'fail_count': ex.get('fail_count', 0),
+        'block_count': ex.get('block_count', 0),
         'pass_count': ex.get('pass_count', 0),
         'comment': ex.get('comment', ''),
+        'performer': ex.get('performer', ''),
     }
 
 
@@ -152,9 +154,10 @@ def complete():
     body = request.get_json(silent=True) or {}
     execution_id = body.get('execution_id', '').strip()
     fail_count = body.get('fail_count', 0)
+    block_count = body.get('block_count', 0)
     if not execution_id:
         return jsonify({'error': 'execution_id required'}), 400
-    ex = ExecutionRepository.complete(execution_id, fail_count)
+    ex = ExecutionRepository.complete(execution_id, fail_count, block_count)
     if ex is None:
         return jsonify({'error': 'not found or invalid state'}), 404
     return jsonify(ex)
@@ -168,6 +171,19 @@ def update_comment():
     if not execution_id:
         return jsonify({'error': 'execution_id required'}), 400
     ex = ExecutionRepository.update_comment(execution_id, comment)
+    if ex is None:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify({'ok': True})
+
+
+@api_bp.route('/performer', methods=['PUT'])
+def update_performer():
+    body = request.get_json(silent=True) or {}
+    execution_id = body.get('execution_id', '').strip()
+    performer = body.get('performer', '')
+    if not execution_id:
+        return jsonify({'error': 'execution_id required'}), 400
+    ex = ExecutionRepository.update_performer(execution_id, performer)
     if ex is None:
         return jsonify({'error': 'not found'}), 404
     return jsonify({'ok': True})

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -33,11 +33,7 @@ function formatElapsed(seconds) {
 
 function formatMinutes(mins) {
   if (!mins) return '-';
-  const h = Math.floor(mins / 60);
-  const m = mins % 60;
-  if (h && m) return `${h}h ${m}m`;
-  if (h) return `${h}h`;
-  return `${m}m`;
+  return `${mins}분`;
 }
 
 function escHtml(s) {
@@ -456,7 +452,23 @@ function _computeElapsed(ex) {
 
 // ── 초기화 ────────────────────────────────────────────────────────────────
 
+function toggleFullscreen() {
+  if (!document.fullscreenElement) {
+    document.documentElement.requestFullscreen().catch(() => {});
+    document.getElementById('fullscreen-icon').className = 'bi bi-fullscreen-exit';
+  } else {
+    document.exitFullscreen();
+    document.getElementById('fullscreen-icon').className = 'bi bi-fullscreen';
+  }
+}
+
+document.addEventListener('fullscreenchange', () => {
+  const icon = document.getElementById('fullscreen-icon');
+  if (icon) icon.className = document.fullscreenElement ? 'bi bi-fullscreen-exit' : 'bi bi-fullscreen';
+});
+
 document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('btn-fullscreen').addEventListener('click', toggleFullscreen);
   document.getElementById('filter-date').addEventListener('change', loadList);
   document.getElementById('filter-location').addEventListener('change', loadList);
   document.getElementById('search-input').addEventListener('input', e => {

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -2,6 +2,7 @@
 
 let _item = null;
 let _pendingComment = '';
+let _pendingPerformer = '';
 
 // 타이머
 let _timerInterval = null;
@@ -9,10 +10,10 @@ let _timerBase = 0;
 let _timerStart = null;
 
 const STATUS_CFG = {
-  pending:     { bg: '#f8fafc', border: '#cbd5e1', badge: 'bg-secondary',         label: '대기' },
-  in_progress: { bg: '#eff6ff', border: '#3b82f6', badge: 'bg-primary',           label: '진행 중' },
-  paused:      { bg: '#fffbeb', border: '#f59e0b', badge: 'bg-warning text-dark',  label: '일시정지' },
-  completed:   { bg: '#f0fdf4', border: '#22c55e', badge: 'bg-success',            label: '완료' },
+  pending:     { bg: '#f1f5f9', border: '#94a3b8', badge: 'bg-secondary',         label: '대기' },
+  in_progress: { bg: '#dbeafe', border: '#3b82f6', badge: 'bg-primary',           label: '진행 중' },
+  paused:      { bg: '#fef9c3', border: '#eab308', badge: 'bg-warning text-dark',  label: '일시정지' },
+  completed:   { bg: '#dcfce7', border: '#22c55e', badge: 'bg-success',            label: '완료' },
 };
 
 // ── 유틸 ──────────────────────────────────────────────────────────────────
@@ -26,9 +27,7 @@ function formatElapsed(seconds) {
 
 function formatMinutes(mins) {
   if (!mins) return '-';
-  const h = Math.floor(mins / 60), m = mins % 60;
-  if (h && m) return `${h}h ${m}m`;
-  return h ? `${h}h` : `${m}m`;
+  return `${mins}분`;
 }
 
 function escHtml(s) {
@@ -44,6 +43,21 @@ async function apiFetch(url, method = 'GET', body = null) {
   if (!r.ok) throw new Error(`API error ${r.status}`);
   return r.json();
 }
+
+// ── 전체화면 (#63) ────────────────────────────────────────────────────────
+
+function toggleFullscreen() {
+  if (!document.fullscreenElement) {
+    document.documentElement.requestFullscreen().catch(() => {});
+  } else {
+    document.exitFullscreen();
+  }
+}
+
+document.addEventListener('fullscreenchange', () => {
+  const icon = document.getElementById('fullscreen-icon');
+  if (icon) icon.className = document.fullscreenElement ? 'bi bi-fullscreen-exit' : 'bi bi-fullscreen';
+});
 
 // ── 타이머 ────────────────────────────────────────────────────────────────
 
@@ -64,7 +78,7 @@ function stopLocalTimer() {
   _timerBase = 0; _timerStart = null;
 }
 
-// ── 렌더링 ────────────────────────────────────────────────────────────────
+// ── 렌더링 (#62 리디자인) ─────────────────────────────────────────────────
 
 function renderPage() {
   const item   = _item;
@@ -75,167 +89,230 @@ function renderPage() {
   document.getElementById('page-title').textContent =
     `${item.identifier_id} — ${item.identifier_name}`;
 
-  // 상태 헤더
+  // ── 상태 헤더 + 타이머 ────────────────────────────────────────────────
   const elapsed = ex?.elapsed_seconds ?? 0;
   let actionBtn;
-  if      (status === 'pending')     actionBtn = `<button class="btn btn-success px-4" onclick="doStart()"><i class="bi bi-play-fill me-1"></i>시험시작</button>`;
-  else if (status === 'in_progress') actionBtn = `<button class="btn btn-warning px-4" onclick="doPause()"><i class="bi bi-pause-fill me-1"></i>일시정지</button>`;
-  else if (status === 'paused')      actionBtn = `<button class="btn btn-primary px-4" onclick="doResume()"><i class="bi bi-play-fill me-1"></i>재시작</button>`;
-  else                               actionBtn = '';
+  if      (status === 'pending')     actionBtn = `<button class="btn btn-success btn-lg px-5 fs-5" onclick="doStart()"><i class="bi bi-play-fill me-2"></i>시험시작</button>`;
+  else if (status === 'in_progress') actionBtn = `<button class="btn btn-warning btn-lg px-5 fs-5" onclick="doPause()"><i class="bi bi-pause-fill me-2"></i>일시정지</button>`;
+  else if (status === 'paused')      actionBtn = `<button class="btn btn-primary btn-lg px-5 fs-5" onclick="doResume()"><i class="bi bi-play-fill me-2"></i>재시작</button>`;
+  else                               actionBtn = `<span class="fs-4 fw-semibold text-success"><i class="bi bi-check-circle-fill me-2"></i>시험 완료</span>`;
 
-  const timerColor = status === 'pending' ? '#94a3b8' : '#1e293b';
-  const statusHeader = `
-  <div class="rounded-3 px-4 py-3 mb-3 d-flex align-items-center justify-content-between gap-3"
-       style="background:${cfg.bg};border-left:4px solid ${cfg.border}">
-    <span class="badge ${cfg.badge} px-3 py-2" style="font-size:.85rem">${cfg.label}</span>
+  const timerColor = status === 'pending' ? '#94a3b8' : '#0f172a';
+
+  const statusCard = `
+  <div class="rounded-3 p-4 mb-4 d-flex align-items-center justify-content-between gap-4"
+       style="background:${cfg.bg};border-left:6px solid ${cfg.border}">
+    <span class="badge ${cfg.badge} px-3 py-2" style="font-size:1rem;min-width:90px;text-align:center">${cfg.label}</span>
     <div class="text-center flex-grow-1">
       <div id="timer-display" class="font-monospace fw-bold"
-           style="font-size:2.4rem;letter-spacing:.05em;color:${timerColor};line-height:1">
+           style="font-size:4rem;letter-spacing:.06em;color:${timerColor};line-height:1.1">
         ${formatElapsed(elapsed)}
       </div>
-      <div class="text-muted" style="font-size:.72rem;margin-top:2px">경과 시간</div>
+      <div class="text-muted mt-1" style="font-size:.8rem">경과 시간</div>
     </div>
     <div>${actionBtn}</div>
   </div>`;
 
-  // 정보 그리드
+  // ── 정보 그리드 ────────────────────────────────────────────────────────
   const assignee = (item.assignee_names || []).join(', ') || '-';
   const infoItems = [
-    ['식별자',   `<code class="text-primary">${escHtml(item.identifier_id)}</code>`],
+    ['식별자',   `<code class="text-primary fs-6">${escHtml(item.identifier_id)}</code>`],
     ['문서',     escHtml(item.doc_name || '-')],
     ['시험항목', escHtml(item.identifier_name)],
     ['담당자',   escHtml(assignee)],
     ['장소',     escHtml(item.location_name || '-')],
     ['날짜',     escHtml(item.scheduled_date || '-')],
-    ['소요시간', formatMinutes(item.estimated_minutes)],
-    ex ? ['총 건수', `<strong>${ex.total_count}</strong>건`] : null,
+    ['예상시간', formatMinutes(item.estimated_minutes)],   // #64
+    ex ? ['총 건수', `<strong class="fs-6">${ex.total_count}</strong>건`] : null,
   ].filter(Boolean);
 
   const infoGrid = `
-  <div class="row g-0 mb-3 border rounded-3 overflow-hidden small">
+  <div class="row g-0 mb-4 border rounded-3 overflow-hidden">
     ${infoItems.map(([k, v], i) => `
-    <div class="col-6 px-3 py-2 ${i % 2 === 0 ? 'border-end' : ''} ${i >= 2 ? 'border-top' : ''}">
-      <span class="text-muted me-2" style="min-width:54px;display:inline-block">${k}</span>${v}
+    <div class="col-6 px-4 py-3 ${i % 2 === 0 ? 'border-end' : ''} ${i >= 2 ? 'border-top' : ''}">
+      <span class="text-muted me-3" style="min-width:64px;display:inline-block;font-size:.85rem">${k}</span>
+      <span style="font-size:.95rem">${v}</span>
     </div>`).join('')}
   </div>`;
 
-  // FAIL / PASS
+  // ── 수행자 (#60) ──────────────────────────────────────────────────────
+  const performerValue = ex ? escHtml(ex.performer || '') : escHtml(_pendingPerformer);
+  const performerHtml = `
+  <div class="mb-4">
+    <label class="form-label fw-semibold mb-2">
+      <i class="bi bi-person-fill me-1"></i>수행자
+    </label>
+    <input type="text" id="performer-input" class="form-control form-control-lg"
+      placeholder="시험 수행자 이름 입력…" value="${performerValue}">
+  </div>`;
+
+  // ── FAIL / BLOCK / PASS (#59) ─────────────────────────────────────────
   let failPassHtml;
   if (status === 'completed') {
     failPassHtml = `
-    <div class="d-flex align-items-center justify-content-center gap-4 mb-3 py-3 rounded-3 border">
-      <div class="text-center">
-        <div class="fs-4 fw-bold text-success">${ex.pass_count}</div>
-        <div class="text-muted small">PASS</div>
+    <div class="d-flex align-items-stretch justify-content-center gap-0 mb-4 border rounded-3 overflow-hidden">
+      <div class="text-center flex-fill py-4 px-3 bg-danger bg-opacity-10">
+        <div class="fs-1 fw-bold text-danger">${ex.fail_count}</div>
+        <div class="text-muted fw-semibold">FAIL</div>
       </div>
-      <div class="text-muted fs-4">|</div>
-      <div class="text-center">
-        <div class="fs-4 fw-bold text-danger">${ex.fail_count}</div>
-        <div class="text-muted small">FAIL</div>
+      <div class="border-start border-end text-center flex-fill py-4 px-3 bg-warning bg-opacity-10">
+        <div class="fs-1 fw-bold text-warning">${ex.block_count ?? 0}</div>
+        <div class="text-muted fw-semibold">BLOCK</div>
       </div>
-      <div class="text-muted small align-self-center">/ 총 ${ex.total_count}건</div>
+      <div class="text-center flex-fill py-4 px-3 bg-success bg-opacity-10">
+        <div class="fs-1 fw-bold text-success">${ex.pass_count}</div>
+        <div class="text-muted fw-semibold">PASS</div>
+      </div>
+      <div class="text-center flex-fill py-4 px-3 bg-light">
+        <div class="fs-1 fw-bold text-secondary">${ex.total_count}</div>
+        <div class="text-muted fw-semibold">총 건수</div>
+      </div>
     </div>`;
   } else {
-    const dis   = !ex ? 'disabled' : '';
-    const failV = ex ? ex.fail_count : 0;
-    const passV = ex ? ex.pass_count : 0;
-    const total = ex ? `/ 총 ${ex.total_count}건` : '';
-    const maxA  = ex ? `max="${ex.total_count}"` : '';
+    const dis    = !ex ? 'disabled' : '';
+    const failV  = ex ? ex.fail_count  : 0;
+    const blockV = ex ? (ex.block_count ?? 0) : 0;
+    const passV  = ex ? ex.pass_count  : 0;
+    const total  = ex ? ex.total_count : 0;
+    const maxA   = ex ? `max="${total}"` : '';
     failPassHtml = `
-    <div class="d-flex align-items-center gap-3 mb-3 px-3 py-2 border rounded-3 bg-light">
-      <span class="text-muted small fw-medium">FAIL</span>
-      <input type="number" id="fail-input" class="form-control form-control-sm text-center fw-bold"
-             style="width:68px" min="0" ${maxA} value="${failV}" ${dis} oninput="updatePass()">
-      <span class="text-muted">→</span>
-      <span class="text-muted small fw-medium">PASS</span>
-      <span id="pass-display" class="fs-5 fw-bold text-success">${passV}</span>
-      <span class="text-muted small ms-auto">${total}</span>
+    <div class="mb-4 border rounded-3 overflow-hidden">
+      <div class="d-flex align-items-stretch">
+        <div class="flex-fill text-center p-3 bg-danger bg-opacity-10 border-end">
+          <label class="form-label fw-bold text-danger mb-2 d-block">FAIL</label>
+          <input type="number" id="fail-input"
+                 class="form-control form-control-lg text-center fw-bold text-danger border-danger"
+                 style="font-size:1.8rem;max-width:140px;margin:0 auto"
+                 min="0" ${maxA} value="${failV}" ${dis} oninput="updatePass()">
+        </div>
+        <div class="flex-fill text-center p-3 bg-warning bg-opacity-10 border-end">
+          <label class="form-label fw-bold text-warning mb-2 d-block">BLOCK</label>
+          <input type="number" id="block-input"
+                 class="form-control form-control-lg text-center fw-bold text-warning border-warning"
+                 style="font-size:1.8rem;max-width:140px;margin:0 auto"
+                 min="0" ${maxA} value="${blockV}" ${dis} oninput="updatePass()">
+        </div>
+        <div class="flex-fill text-center p-3 bg-success bg-opacity-10 border-end">
+          <div class="form-label fw-bold text-success mb-2">PASS</div>
+          <div id="pass-display" class="fw-bold text-success" style="font-size:1.8rem">${passV}</div>
+        </div>
+        <div class="flex-fill text-center p-3 bg-light">
+          <div class="form-label fw-semibold text-muted mb-2">총 건수</div>
+          <div class="fw-bold text-secondary" style="font-size:1.8rem">${total}</div>
+        </div>
+      </div>
     </div>`;
   }
 
-  // 코멘트
+  // ── 코멘트 (#61 높이 증가) ────────────────────────────────────────────
   const commentValue = ex ? escHtml(ex.comment || '') : escHtml(_pendingComment);
   const commentHtml = `
-  <div class="mb-3">
-    <label class="form-label small text-muted mb-1">
+  <div class="mb-4">
+    <label class="form-label fw-semibold mb-2">
       <i class="bi bi-chat-left-text me-1"></i>코멘트
     </label>
-    <textarea id="comment-input" class="form-control form-control-sm" rows="3"
-      placeholder="시험 관련 코멘트 입력…">${commentValue}</textarea>
+    <textarea id="comment-input" class="form-control form-control-lg" rows="6"
+      placeholder="시험 관련 코멘트를 입력하세요…">${commentValue}</textarea>
   </div>`;
 
-  // 하단 버튼
+  // ── 하단 버튼 ─────────────────────────────────────────────────────────
   let footerHtml;
   if (status === 'completed') {
     footerHtml = `
-    <div class="d-flex justify-content-between">
-      <button class="btn btn-outline-secondary btn-sm" onclick="doReset()">
+    <div class="d-flex justify-content-between gap-3">
+      <button class="btn btn-outline-secondary btn-lg px-4" onclick="doReset()">
         <i class="bi bi-arrow-counterclockwise me-1"></i>재시험
       </button>
-      <a href="/execution/" class="btn btn-secondary btn-sm">목록으로</a>
+      <a href="/execution/" class="btn btn-secondary btn-lg px-4">
+        <i class="bi bi-list-ul me-1"></i>목록으로
+      </a>
     </div>`;
   } else {
     const dis = !ex ? 'disabled' : '';
     footerHtml = `
-    <div class="d-flex justify-content-between">
-      <button class="btn btn-outline-secondary btn-sm" onclick="doReset()" ${dis}>
+    <div class="d-flex justify-content-between gap-3">
+      <button class="btn btn-outline-secondary btn-lg px-4" onclick="doReset()" ${dis}>
         <i class="bi bi-arrow-counterclockwise me-1"></i>재시험
       </button>
-      <button class="btn btn-primary" onclick="doComplete()" ${dis}>
-        <i class="bi bi-check-lg me-1"></i>시험완료
+      <button class="btn btn-primary btn-lg px-5" onclick="doComplete()" ${dis}>
+        <i class="bi bi-check-lg me-2"></i>시험완료
       </button>
     </div>`;
   }
 
   document.getElementById('detail-content').innerHTML =
-    `${statusHeader}${infoGrid}${failPassHtml}${commentHtml}${footerHtml}`;
+    `${statusCard}${infoGrid}${performerHtml}${failPassHtml}${commentHtml}${footerHtml}`;
 
-  _attachCommentHandler();
+  _attachHandlers();
   startLocalTimer();
 }
 
-function _attachCommentHandler() {
+// ── 핸들러 연결 ───────────────────────────────────────────────────────────
+
+function _attachHandlers() {
+  // 코멘트
   const ta = document.getElementById('comment-input');
-  if (!ta) return;
-  const save = async () => {
-    if (!_item?.execution?.id) { _pendingComment = ta.value; return; }
-    try {
-      await apiFetch('/execution/api/comment', 'PUT', {
-        execution_id: _item.execution.id,
-        comment: ta.value,
-      });
-      _item.execution.comment = ta.value;
-    } catch { /* 무시 */ }
-  };
-  ta.addEventListener('blur', save);
-  ta.addEventListener('change', save);
+  if (ta) {
+    const saveComment = async () => {
+      if (!_item?.execution?.id) { _pendingComment = ta.value; return; }
+      try {
+        await apiFetch('/execution/api/comment', 'PUT', {
+          execution_id: _item.execution.id, comment: ta.value,
+        });
+        _item.execution.comment = ta.value;
+      } catch { /* 무시 */ }
+    };
+    ta.addEventListener('blur', saveComment);
+    ta.addEventListener('change', saveComment);
+  }
+
+  // 수행자
+  const pi = document.getElementById('performer-input');
+  if (pi) {
+    const savePerformer = async () => {
+      if (!_item?.execution?.id) { _pendingPerformer = pi.value; return; }
+      try {
+        await apiFetch('/execution/api/performer', 'PUT', {
+          execution_id: _item.execution.id, performer: pi.value,
+        });
+        _item.execution.performer = pi.value;
+      } catch { /* 무시 */ }
+    };
+    pi.addEventListener('blur', savePerformer);
+    pi.addEventListener('change', savePerformer);
+  }
 }
 
 function updatePass() {
   if (!_item?.execution) return;
   const total = _item.execution.total_count;
-  const fail  = parseInt(document.getElementById('fail-input').value) || 0;
-  document.getElementById('pass-display').textContent = Math.max(0, total - fail);
+  const fail  = parseInt(document.getElementById('fail-input')?.value  || 0) || 0;
+  const block = parseInt(document.getElementById('block-input')?.value || 0) || 0;
+  document.getElementById('pass-display').textContent = Math.max(0, total - fail - block);
 }
 
 // ── 액션 핸들러 ───────────────────────────────────────────────────────────
 
 async function doStart() {
   const ta = document.getElementById('comment-input');
-  if (ta) _pendingComment = ta.value;
+  const pi = document.getElementById('performer-input');
+  if (ta) _pendingComment   = ta.value;
+  if (pi) _pendingPerformer = pi.value;
+
   try {
     const ex = await apiFetch('/execution/api/start', 'POST', {
-      identifier_id: _item.identifier_id,
-      task_id: _item.task_id,
+      identifier_id: _item.identifier_id, task_id: _item.task_id,
     });
     _item.execution = {
       id: ex.id, status: ex.status, elapsed_seconds: 0,
-      total_count: ex.total_count, fail_count: 0, pass_count: 0, comment: _pendingComment,
+      total_count: ex.total_count, fail_count: 0, block_count: 0, pass_count: 0,
+      comment: _pendingComment, performer: _pendingPerformer,
     };
-    if (_pendingComment) {
-      await apiFetch('/execution/api/comment', 'PUT', { execution_id: ex.id, comment: _pendingComment });
-      _pendingComment = '';
-    }
+    const saves = [];
+    if (_pendingComment)   saves.push(apiFetch('/execution/api/comment', 'PUT', { execution_id: ex.id, comment: _pendingComment }));
+    if (_pendingPerformer) saves.push(apiFetch('/execution/api/performer', 'PUT', { execution_id: ex.id, performer: _pendingPerformer }));
+    await Promise.all(saves);
+    _pendingComment = ''; _pendingPerformer = '';
     renderPage();
   } catch { alert('시험시작 실패'); }
 }
@@ -259,16 +336,17 @@ async function doResume() {
 }
 
 async function doComplete() {
-  const failInput = document.getElementById('fail-input');
-  const failCount = parseInt(failInput?.value || 0) || 0;
+  const failCount  = parseInt(document.getElementById('fail-input')?.value  || 0) || 0;
+  const blockCount = parseInt(document.getElementById('block-input')?.value || 0) || 0;
   try {
     const ex = await apiFetch('/execution/api/complete', 'POST', {
-      execution_id: _item.execution.id, fail_count: failCount,
+      execution_id: _item.execution.id, fail_count: failCount, block_count: blockCount,
     });
     stopLocalTimer();
     _item.execution = {
       ..._item.execution, status: 'completed',
-      fail_count: ex.fail_count, pass_count: ex.pass_count, elapsed_seconds: _computeElapsed(ex),
+      fail_count: ex.fail_count, block_count: ex.block_count ?? blockCount,
+      pass_count: ex.pass_count, elapsed_seconds: _computeElapsed(ex),
     };
     renderPage();
   } catch { alert('완료 처리 실패'); }
@@ -281,6 +359,7 @@ async function doReset() {
     await apiFetch('/execution/api/reset', 'POST', { execution_id: _item.execution.id });
     stopLocalTimer();
     _item.execution = null;
+    _pendingComment = ''; _pendingPerformer = '';
     renderPage();
   } catch { alert('재시험 처리 실패'); }
 }
@@ -299,12 +378,15 @@ function _computeElapsed(ex) {
 // ── 초기화 ────────────────────────────────────────────────────────────────
 
 document.addEventListener('DOMContentLoaded', async () => {
+  // 전체화면 버튼 (#63)
+  document.getElementById('btn-fullscreen').addEventListener('click', toggleFullscreen);
+
   try {
     _item = await apiFetch(`/execution/api/item/${encodeURIComponent(IDENTIFIER_ID)}`);
     renderPage();
   } catch {
     document.getElementById('detail-content').innerHTML =
-      '<div class="alert alert-danger">항목을 찾을 수 없습니다.</div>';
+      '<div class="alert alert-danger mt-3">항목을 찾을 수 없습니다.</div>';
   }
 
   // 스페이스바 단축키

--- a/app/templates/execution/detail.html
+++ b/app/templates/execution/detail.html
@@ -5,11 +5,16 @@
 <div class="container py-4" style="max-width:720px">
 
   <!-- 헤더 -->
-  <div class="d-flex align-items-center gap-3 mb-4">
-    <a href="{{ url_for('execution.index') }}" class="btn btn-sm btn-outline-secondary">
-      <i class="bi bi-arrow-left"></i> 목록
-    </a>
-    <h5 class="mb-0" id="page-title">{{ identifier_id }}</h5>
+  <div class="d-flex align-items-center justify-content-between gap-3 mb-4">
+    <div class="d-flex align-items-center gap-3">
+      <a href="{{ url_for('execution.index') }}" class="btn btn-sm btn-outline-secondary">
+        <i class="bi bi-arrow-left"></i> 목록
+      </a>
+      <h5 class="mb-0" id="page-title">{{ identifier_id }}</h5>
+    </div>
+    <button id="btn-fullscreen" class="btn btn-sm btn-outline-secondary" title="전체화면">
+      <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
+    </button>
   </div>
 
   <!-- 컨텐츠 영역 -->

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -3,8 +3,11 @@
 
 {% block content_sub %}
 <div class="container-fluid py-3">
-  <div class="d-flex align-items-center gap-3 mb-3">
+  <div class="d-flex align-items-center justify-content-between mb-3">
     <h4 class="mb-0">시험 실행</h4>
+    <button id="btn-fullscreen" class="btn btn-sm btn-outline-secondary" title="전체화면">
+      <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
+    </button>
   </div>
 
   <!-- 필터 바 -->
@@ -46,7 +49,7 @@
           <th class="sortable" data-sort="date" style="width:90px;cursor:pointer">
             날짜 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
           </th>
-          <th style="width:80px">소요시간</th>
+          <th style="width:80px">예상시간</th>
           <th class="sortable" data-sort="status" style="width:120px;cursor:pointer">
             상태 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
           </th>


### PR DESCRIPTION
## Summary
- **#59** BLOCK 카운트 필드 추가, PASS 자동 계산 (`total - fail - block`)
- **#60** 수행자(performer) 입력 필드 추가
- **#61** 코멘트 textarea 6행으로 확대
- **#62** 상세 페이지 레이아웃 재설계 (큰 타이머·컬러 상태카드·2컬럼 정보그리드·대형 버튼)
- **#63** 전체화면(키오스크) 모드 버튼 추가 (index + detail 양쪽)
- **#64** 예상시간 표시 형식 수정 (`${mins}분` 단위)

## Test plan
- [ ] 시험 시작 → FAIL/BLOCK 입력 시 PASS 자동 계산 확인
- [ ] 수행자 입력 후 blur/change 시 서버 저장 확인
- [ ] 전체화면 버튼 동작 및 아이콘 토글 확인
- [ ] 예상시간 열에 `분` 단위 표시 확인
- [ ] 상세 페이지 레이아웃 전체 확인 (pending → in_progress → paused → completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)