### PR TITLE
feat(execution): 시험 실행 페이지를 독립 레이아웃으로 분리

### DIFF
--- a/app/templates/execution/base.html
+++ b/app/templates/execution/base.html
@@ -6,22 +6,20 @@
   <title>{% block title %}시험 실행{% endblock %}</title>
   <link href="{{ url_for('static', filename='schedule/vendor/bootstrap.min.css') }}" rel="stylesheet">
   <link href="{{ url_for('static', filename='schedule/vendor/bootstrap-icons.css') }}" rel="stylesheet">
-  <link href="{{ url_for('static', filename='execution/css/style.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='execution/css/style.css') }}?v={{ cache_bust }}" rel="stylesheet">
+  {% block head %}{% endblock %}
 </head>
 <body>
   <div class="exec-toolbar">
     <div class="exec-toolbar-left">
-      <i class="bi bi-clipboard-check"></i>
-      <span class="exec-toolbar-title">시험 실행</span>
+      <i class="bi bi-play-circle"></i> 시험 실행
     </div>
     <div class="exec-toolbar-right">
-      <a href="{{ url_for('schedule.week_view') }}" class="btn btn-sm btn-outline-secondary">
-        <i class="bi bi-calendar-week"></i> 시간표
-      </a>
+      {% block toolbar_right %}{% endblock %}
     </div>
   </div>
 
-  <main class="container mt-3">
+  <main class="{% block main_class %}container-fluid py-3{% endblock %}">
     {% block content %}{% endblock %}
   </main>
 

--- a/app/templates/execution/detail.html
+++ b/app/templates/execution/detail.html
@@ -1,33 +1,29 @@
-{% extends "schedule/base.html" %}
+{% extends "execution/base.html" %}
 {% block title %}시험 실행 — {{ identifier_id }}{% endblock %}
 
-{% block content_sub %}
-<div class="container py-4" style="max-width:720px">
+{% block toolbar_right %}
+<a href="{{ url_for('execution.index') }}" class="btn btn-sm btn-outline-light">
+  <i class="bi bi-arrow-left"></i> 목록
+</a>
+<button id="btn-fullscreen" class="btn btn-sm btn-outline-light" title="전체화면">
+  <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
+</button>
+{% endblock %}
 
-  <!-- 헤더 -->
-  <div class="d-flex align-items-center justify-content-between gap-3 mb-4">
-    <div class="d-flex align-items-center gap-3">
-      <a href="{{ url_for('execution.index') }}" class="btn btn-sm btn-outline-secondary">
-        <i class="bi bi-arrow-left"></i> 목록
-      </a>
-      <h5 class="mb-0" id="page-title">{{ identifier_id }}</h5>
-    </div>
-    <button id="btn-fullscreen" class="btn btn-sm btn-outline-secondary" title="전체화면">
-      <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
-    </button>
-  </div>
+{% block main_class %}container py-4{% endblock %}
 
-  <!-- 컨텐츠 영역 -->
+{% block content %}
+<div style="max-width:720px; margin:0 auto">
+  <h5 class="mb-4" id="page-title">{{ identifier_id }}</h5>
   <div id="detail-content">
     <div class="text-center py-5 text-muted">
       <div class="spinner-border spinner-border-sm me-2"></div>로딩 중…
     </div>
   </div>
-
 </div>
 {% endblock %}
 
-{% block scripts_sub %}
+{% block scripts %}
 <script>var IDENTIFIER_ID = {{ identifier_id | tojson }};</script>
 <script src="{{ url_for('static', filename='execution/js/execution-detail.js') }}?v={{ cache_bust }}"></script>
 {% endblock %}

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -1,15 +1,13 @@
-{% extends "schedule/base.html" %}
+{% extends "execution/base.html" %}
 {% block title %}시험 실행{% endblock %}
 
-{% block content_sub %}
-<div class="container-fluid py-3">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h4 class="mb-0">시험 실행</h4>
-    <button id="btn-fullscreen" class="btn btn-sm btn-outline-secondary" title="전체화면">
-      <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
-    </button>
-  </div>
+{% block toolbar_right %}
+<button id="btn-fullscreen" class="btn btn-sm btn-outline-light" title="전체화면">
+  <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
+</button>
+{% endblock %}
 
+{% block content %}
   <!-- 필터 바 -->
   <div class="d-flex flex-wrap gap-2 mb-2">
     <select id="filter-date" class="form-select form-select-sm" style="width:auto">
@@ -60,7 +58,6 @@
       </tbody>
     </table>
   </div>
-</div>
 
 <!-- 실행 모달 -->
 <div class="modal fade" id="execModal" tabindex="-1" aria-labelledby="execModalTitle" aria-hidden="true"
@@ -78,6 +75,6 @@
 </div>
 {% endblock %}
 
-{% block scripts_sub %}
+{% block scripts %}
 <script src="{{ url_for('static', filename='execution/js/execution-app.js') }}?v={{ cache_bust }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- `execution/base.html`을 완전한 독립 HTML 구조로 정비 (schedule/base.html 의존 제거)
- `index.html`, `detail.html`을 `execution/base.html`로 전환
- 전체화면 버튼 / 목록 링크를 `toolbar_right` 블록으로 이동 (어두운 exec-toolbar에 맞춤)
- `/execution/`, `/execution/<id>` URL로 직접 진입 가능

## Test plan
- [ ] `/execution/` 직접 접근 시 exec-toolbar + 목록 테이블 정상 렌더링
- [ ] `/execution/<id>` 직접 접근 시 상세 페이지 정상 렌더링
- [ ] 전체화면 버튼 동작 확인
- [ ] 목록 링크로 돌아가기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)