### PR TITLE
fix(execution): 상세 페이지 사이드바 너비 및 글자 크기 확대 (#68)

### DIFF
--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -103,15 +103,15 @@ function renderPage() {
   ].filter(Boolean);
 
   const leftPanel = `
-  <div class="d-flex flex-column h-100 border-end overflow-y-auto" style="width:260px;flex-shrink:0;padding:1.25rem 1rem">
+  <div class="d-flex flex-column h-100 border-end overflow-y-auto" style="width:320px;flex-shrink:0;padding:1.25rem 1.25rem">
     <div class="mb-3">
-      <span class="badge ${cfg.badge} px-3 py-2 w-100 text-center" style="font-size:.95rem">${cfg.label}</span>
+      <span class="badge ${cfg.badge} px-3 py-2 w-100 text-center" style="font-size:1rem">${cfg.label}</span>
     </div>
-    <table class="table table-sm table-borderless mb-0" style="font-size:.85rem">
+    <table class="table table-sm table-borderless mb-0" style="font-size:.95rem">
       <tbody>
         ${infoRows.map(([k, v]) => `
         <tr>
-          <td class="text-muted pe-2 text-nowrap" style="width:64px">${k}</td>
+          <td class="text-muted pe-2 text-nowrap" style="width:72px">${k}</td>
           <td>${v}</td>
         </tr>`).join('')}
       </tbody>


### PR DESCRIPTION
## Summary
- 사이드바 너비 260px → 320px
- 정보 테이블 글자 크기 .85rem → .95rem
- 상태 배지 글자 크기 .95rem → 1rem

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)