### PR TITLE
fix(execution): 사이드바 너비 비율 확대

### DIFF
--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -103,7 +103,7 @@ function renderPage() {
   ].filter(Boolean);
 
   const leftPanel = `
-  <div class="d-flex flex-column h-100 border-end overflow-y-auto" style="width:320px;flex-shrink:0;padding:1.25rem 1.25rem">
+  <div class="d-flex flex-column h-100 border-end overflow-y-auto" style="flex:0 0 38%;min-width:320px;padding:1.25rem 1.25rem">
     <div class="mb-3">
       <span class="badge ${cfg.badge} px-3 py-2 w-100 text-center" style="font-size:1rem">${cfg.label}</span>
     </div>


### PR DESCRIPTION
## Summary
- 사이드바를 고정 320px에서 뷰포트의 38% 비율로 변경
- 내용이 길 때도 잘림 없이 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)