### PR TITLE
feat(execution): 전체 디자인 리뉴얼 + #71 사이드바 순서 변경

### DIFF
--- a/app/static/execution/css/style.css
+++ b/app/static/execution/css/style.css
@@ -1,149 +1,349 @@
-/* Execution page styles */
+/* ─── Execution 독립 레이아웃 ─────────────────────────────────────────── */
+
+:root {
+  --exec-toolbar-h: 52px;
+  --exec-accent: #6366f1;
+  --exec-slate: #0f172a;
+  --exec-border: #e2e8f0;
+}
+
+/* ─── 툴바 ─────────────────────────────────────────────────────────────── */
 .exec-toolbar {
+  height: var(--exec-toolbar-h);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 16px;
-  background: #1e293b;
-  color: #fff;
+  padding: 0 20px;
+  background: var(--exec-slate);
+  border-bottom: 2px solid var(--exec-accent);
+  flex-shrink: 0;
 }
-.exec-toolbar-left {
+
+.exec-toolbar-brand {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-weight: 600;
-  font-size: 0.95rem;
+  gap: 10px;
 }
+.exec-toolbar-brand .brand-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--exec-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: #fff;
+}
+.exec-toolbar-brand .brand-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: -.01em;
+}
+.exec-toolbar-brand .brand-subtitle {
+  font-size: .7rem;
+  color: #94a3b8;
+  margin-top: -2px;
+}
+
 .exec-toolbar-right {
   display: flex;
   align-items: center;
   gap: 8px;
 }
-.exec-nav {
-  display: flex;
-  align-items: center;
-  padding: 12px 0;
-}
-.exec-summary {
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 16px;
-  font-size: 0.85rem;
-}
-.exec-summary-counts {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 6px;
-  flex-wrap: wrap;
-}
-.exec-summary-counts span { font-weight: 600; }
-.exec-progress {
-  height: 8px;
-  background: #e2e8f0;
-  border-radius: 4px;
-  overflow: hidden;
-}
-.exec-progress-bar {
-  height: 100%;
-  background: #16a34a;
-  border-radius: 4px;
-  transition: width 0.3s;
+.exec-toolbar-right .btn {
+  font-size: .8rem;
 }
 
-/* Block card */
-.exec-block {
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  margin-bottom: 16px;
-  overflow: hidden;
-}
-.exec-block-header {
-  background: #f1f5f9;
-  padding: 10px 14px;
+/* ─── 목록 페이지 헤더 ─────────────────────────────────────────────────── */
+.exec-page-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid #e2e8f0;
+  justify-content: space-between;
+  padding: 20px 24px 12px;
+  border-bottom: 1px solid var(--exec-border);
+  background: #fff;
 }
-.exec-block-title {
+.exec-page-title {
+  font-size: 1.35rem;
   font-weight: 700;
-  font-size: 0.9rem;
-}
-.exec-block-meta {
-  font-size: 0.78rem;
-  color: #64748b;
-}
-
-/* Identifier row */
-.exec-id-row {
-  padding: 10px 14px;
-  border-bottom: 1px solid #f1f5f9;
-}
-.exec-id-row:last-child { border-bottom: none; }
-.exec-id-header {
+  color: var(--exec-slate);
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
+  gap: 10px;
 }
-.exec-id-name {
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-.exec-id-info {
-  font-size: 0.75rem;
-  color: #64748b;
-}
-.exec-status-badge {
-  font-size: 0.7rem;
-  font-weight: 600;
-  padding: 2px 8px;
+.exec-page-title .title-icon {
+  width: 36px;
+  height: 36px;
   border-radius: 10px;
-}
-.exec-status-pending { background: #f3f4f6; color: #6b7280; }
-.exec-status-in_progress { background: #dbeafe; color: #1d4ed8; }
-.exec-status-completed { background: #dcfce7; color: #15803d; }
-
-.exec-id-body {
-  margin-top: 6px;
-}
-.exec-field-row {
+  background: #eef2ff;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  color: var(--exec-accent);
+}
+.exec-item-count {
+  font-size: .8rem;
+  color: #94a3b8;
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+/* ─── 필터 바 ──────────────────────────────────────────────────────────── */
+.exec-filter-bar {
+  padding: 12px 24px;
+  background: #f8fafc;
+  border-bottom: 1px solid var(--exec-border);
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 6px;
   align-items: center;
 }
-.exec-field-row label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #475569;
-  min-width: 65px;
-  flex-shrink: 0;
+.exec-filter-bar .form-select,
+.exec-filter-bar .form-control {
+  border-radius: 8px;
+  border-color: #cbd5e1;
+  font-size: .82rem;
+  background: #fff;
 }
-.exec-field-row input,
-.exec-field-row textarea {
-  font-size: 0.8rem;
-}
-.exec-field-row textarea {
-  resize: vertical;
-  min-height: 32px;
-}
-.exec-result-display {
-  font-size: 0.8rem;
-  margin-top: 4px;
-}
-.exec-actions {
-  display: flex;
-  gap: 6px;
-  margin-top: 8px;
+.exec-filter-bar .form-select:focus,
+.exec-filter-bar .form-control:focus {
+  border-color: var(--exec-accent);
+  box-shadow: 0 0 0 3px rgba(99,102,241,.12);
 }
 
-/* Empty state */
-.exec-empty {
-  text-align: center;
-  padding: 3rem;
-  color: #94a3b8;
+/* ─── 담당자 뱃지 ──────────────────────────────────────────────────────── */
+.exec-assignee-bar {
+  padding: 8px 24px;
+  background: #fff;
+  border-bottom: 1px solid var(--exec-border);
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
 }
-.exec-empty i { font-size: 2rem; }
+.exec-assignee-badge {
+  cursor: pointer;
+  border-radius: 20px;
+  padding: 3px 12px;
+  font-size: .78rem;
+  font-weight: 500;
+  transition: all .15s;
+  border: 1.5px solid #cbd5e1;
+  background: #fff;
+  color: #475569;
+  user-select: none;
+}
+.exec-assignee-badge.active {
+  background: var(--exec-accent);
+  border-color: var(--exec-accent);
+  color: #fff;
+}
+.exec-assignee-badge:hover:not(.active) {
+  border-color: var(--exec-accent);
+  color: var(--exec-accent);
+}
+
+/* ─── 테이블 ───────────────────────────────────────────────────────────── */
+.exec-table-wrapper {
+  flex: 1;
+  overflow: auto;
+}
+.exec-table {
+  font-size: .84rem;
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+}
+.exec-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f8fafc;
+  border-bottom: 2px solid var(--exec-border);
+  padding: 10px 14px;
+  font-size: .75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: #64748b;
+  white-space: nowrap;
+  z-index: 1;
+}
+.exec-table thead th.sortable { cursor: pointer; }
+.exec-table thead th.sortable:hover { color: var(--exec-accent); }
+
+.exec-table tbody tr {
+  cursor: pointer;
+  border-bottom: 1px solid #f1f5f9;
+  transition: background .12s;
+}
+.exec-table tbody tr:hover { background: #f8fafc; }
+.exec-table tbody td {
+  padding: 10px 14px;
+  vertical-align: middle;
+  color: #334155;
+}
+.exec-table .td-doc { color: #64748b; font-size: .8rem; }
+.exec-table .td-id  { font-family: monospace; color: var(--exec-accent); font-weight: 600; }
+.exec-table .td-name { font-weight: 500; color: #1e293b; }
+.exec-table .td-meta { color: #64748b; font-size: .8rem; }
+
+/* 상태별 행 왼쪽 강조 */
+.exec-table tbody tr[data-status="in_progress"] { border-left: 3px solid #3b82f6; }
+.exec-table tbody tr[data-status="paused"]      { border-left: 3px solid #f59e0b; }
+.exec-table tbody tr[data-status="completed"]   { border-left: 3px solid #22c55e; }
+.exec-table tbody tr[data-status="pending"]     { border-left: 3px solid transparent; }
+
+/* ─── 상태 배지 ────────────────────────────────────────────────────────── */
+.exec-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: .75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.exec-badge-pending     { background:#f1f5f9; color:#64748b; }
+.exec-badge-in_progress { background:#dbeafe; color:#1d4ed8; }
+.exec-badge-paused      { background:#fef3c7; color:#b45309; }
+.exec-badge-completed   { background:#dcfce7; color:#15803d; }
+.exec-badge-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: currentColor;
+}
+
+/* ─── 상세 페이지 레이아웃 ─────────────────────────────────────────────── */
+.exec-detail-layout {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* 사이드바 */
+.exec-detail-sidebar {
+  flex: 0 0 38%;
+  min-width: 300px;
+  border-right: 1px solid var(--exec-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  background: #fafafa;
+}
+.exec-sidebar-header {
+  padding: 16px 20px 10px;
+  border-bottom: 1px solid var(--exec-border);
+}
+.exec-sidebar-label {
+  font-size: .68rem;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 8px;
+}
+.exec-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 24px;
+  font-size: .9rem;
+  font-weight: 600;
+}
+.exec-info-table {
+  padding: 12px 20px;
+}
+.exec-info-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid #f1f5f9;
+  font-size: .875rem;
+}
+.exec-info-row:last-child { border-bottom: none; }
+.exec-info-key {
+  flex-shrink: 0;
+  width: 68px;
+  font-size: .75rem;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.exec-info-val {
+  color: #1e293b;
+  word-break: break-all;
+}
+
+/* 메인 패널 */
+.exec-detail-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 20px 24px 16px;
+}
+
+/* 타이머 카드 */
+.exec-timer-card {
+  border-radius: 14px;
+  padding: 20px 24px;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  transition: background .3s, border-color .3s;
+}
+.exec-timer-value {
+  font-family: 'SF Mono', 'Fira Mono', monospace;
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: .04em;
+  line-height: 1;
+}
+.exec-timer-label {
+  font-size: .7rem;
+  color: #94a3b8;
+  margin-top: 3px;
+}
+
+/* FAIL/BLOCK/PASS */
+.exec-counts-bar {
+  display: flex;
+  border: 1px solid var(--exec-border);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+.exec-count-cell {
+  flex: 1;
+  text-align: center;
+  padding: 10px 8px;
+}
+.exec-count-cell + .exec-count-cell { border-left: 1px solid var(--exec-border); }
+.exec-count-label {
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .05em;
+  margin-bottom: 4px;
+}
+.exec-count-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+}
+.exec-count-input {
+  font-size: 1.4rem !important;
+  font-weight: 700 !important;
+  text-align: center;
+  max-width: 90px;
+  margin: 0 auto;
+  border-radius: 8px !important;
+  padding: 2px 6px !important;
+}

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -80,7 +80,7 @@ async function loadList() {
   if (loc)  params.set('location', loc);
 
   document.getElementById('exec-tbody').innerHTML =
-    '<tr><td colspan="8" class="text-center text-muted py-3">로딩 중…</td></tr>';
+    '<tr><td colspan="8" class="text-center text-muted py-5"><div class="spinner-border spinner-border-sm me-2"></div>로딩 중…</td></tr>';
 
   try {
     _allItems = await apiFetch('/execution/api/list?' + params.toString());
@@ -88,7 +88,7 @@ async function loadList() {
     applyAndRender();
   } catch {
     document.getElementById('exec-tbody').innerHTML =
-      '<tr><td colspan="8" class="text-center text-danger">로드 실패</td></tr>';
+      '<tr><td colspan="8" class="text-center text-danger py-4"><i class="bi bi-exclamation-circle me-2"></i>로드 실패</td></tr>';
   }
 }
 
@@ -102,8 +102,8 @@ function renderAssigneeBadges() {
   container.innerHTML = [...all].sort().map(a => {
     const esc = escHtml(a);
     const active = _activeAssignees.has(esc);
-    return `<span class="badge me-1 mb-1 ${active ? 'bg-primary' : 'bg-light text-dark border'}"
-      style="cursor:pointer;font-size:.8rem" onclick="toggleAssignee(${JSON.stringify(esc)})">${esc}</span>`;
+    return `<span class="exec-assignee-badge ${active ? 'active' : ''}"
+      onclick="toggleAssignee(${JSON.stringify(esc)})">${esc}</span>`;
   }).join('');
 }
 
@@ -155,31 +155,33 @@ function applyAndRender() {
 // ── 테이블 렌더링 ─────────────────────────────────────────────────────────
 
 function statusBadge(item) {
-  const ex = item.execution;
-  const s = ex?.status || 'pending';
-  const cfg = STATUS_CFG[s] || STATUS_CFG.pending;
-  const icons = { pending: '○', in_progress: '🔵', paused: '⏸', completed: '✅' };
+  const s = item.execution?.status || 'pending';
   const labels = { pending: '대기', in_progress: '진행 중', paused: '일시정지', completed: '완료' };
-  return `<span class="badge ${cfg.badge}">${icons[s] || '-'} ${labels[s] || '-'}</span>`;
+  return `<span class="exec-badge exec-badge-${s}"><span class="exec-badge-dot"></span>${labels[s] || '-'}</span>`;
 }
 
 function renderTable(items) {
   const tbody = document.getElementById('exec-tbody');
+  const countEl = document.getElementById('item-count');
+  if (countEl) countEl.textContent = items.length ? `${items.length}건` : '';
+
   if (!items.length) {
-    tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">항목 없음</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-5">항목 없음</td></tr>';
     return;
   }
   tbody.innerHTML = items.map(item => {
     const assignee = (item.assignee_names || []).join(', ') || '-';
+    const status = item.execution?.status || 'pending';
     return `
-    <tr data-id="${item.identifier_id}" data-item='${JSON.stringify(item).replace(/'/g,"&#39;")}' style="cursor:pointer">
-      <td class="text-muted small">${escHtml(item.doc_name || '-')}</td>
-      <td><code>${escHtml(item.identifier_id)}</code></td>
-      <td>${escHtml(item.identifier_name)}</td>
-      <td class="text-muted small">${escHtml(assignee)}</td>
-      <td class="text-muted small">${item.location_name || '-'}</td>
-      <td class="text-muted small">${item.scheduled_date || '-'}</td>
-      <td class="text-muted small">${formatMinutes(item.estimated_minutes)}</td>
+    <tr data-id="${item.identifier_id}" data-status="${status}"
+        data-item='${JSON.stringify(item).replace(/'/g,"&#39;")}'>
+      <td class="td-doc">${escHtml(item.doc_name || '-')}</td>
+      <td class="td-id">${escHtml(item.identifier_id)}</td>
+      <td class="td-name">${escHtml(item.identifier_name)}</td>
+      <td class="td-meta">${escHtml(assignee)}</td>
+      <td class="td-meta">${item.location_name || '-'}</td>
+      <td class="td-meta">${item.scheduled_date || '-'}</td>
+      <td class="td-meta">${formatMinutes(item.estimated_minutes)}</td>
       <td>${statusBadge(item)}</td>
     </tr>`;
   }).join('');

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -89,11 +89,11 @@ function renderPage() {
   document.getElementById('page-title').textContent =
     `${item.identifier_id} — ${item.identifier_name}`;
 
-  // ── 왼쪽 패널: 정보 목록 ──────────────────────────────────────────────
+  // ── 왼쪽 패널: 정보 목록 (#71 순서: 문서 → 식별자 → ...) ───────────────
   const assignee = (item.assignee_names || []).join(', ') || '-';
   const infoRows = [
-    ['식별자',   `<code class="text-primary">${escHtml(item.identifier_id)}</code>`],
     ['문서',     escHtml(item.doc_name || '-')],
+    ['식별자',   `<code style="color:#6366f1;font-weight:600">${escHtml(item.identifier_id)}</code>`],
     ['시험항목', escHtml(item.identifier_name)],
     ['담당자',   escHtml(assignee)],
     ['장소',     escHtml(item.location_name || '-')],
@@ -103,60 +103,62 @@ function renderPage() {
   ].filter(Boolean);
 
   const leftPanel = `
-  <div class="d-flex flex-column h-100 border-end overflow-y-auto" style="flex:0 0 38%;min-width:320px;padding:1.25rem 1.25rem">
-    <div class="mb-3">
-      <span class="badge ${cfg.badge} px-3 py-2 w-100 text-center" style="font-size:1rem">${cfg.label}</span>
+  <div class="exec-detail-sidebar">
+    <div class="exec-sidebar-header">
+      <div class="exec-sidebar-label">상태</div>
+      <span class="exec-status-chip exec-badge-${status}" style="background:${cfg.bg};color:${cfg.border};border:1.5px solid ${cfg.border}">
+        <span style="width:8px;height:8px;border-radius:50%;background:${cfg.border};display:inline-block"></span>
+        ${cfg.label}
+      </span>
     </div>
-    <table class="table table-sm table-borderless mb-0" style="font-size:.95rem">
-      <tbody>
-        ${infoRows.map(([k, v]) => `
-        <tr>
-          <td class="text-muted pe-2 text-nowrap" style="width:72px">${k}</td>
-          <td>${v}</td>
-        </tr>`).join('')}
-      </tbody>
-    </table>
+    <div class="exec-info-table">
+      <div class="exec-sidebar-label mb-2">시험 정보</div>
+      ${infoRows.map(([k, v]) => `
+      <div class="exec-info-row">
+        <span class="exec-info-key">${k}</span>
+        <span class="exec-info-val">${v}</span>
+      </div>`).join('')}
+    </div>
   </div>`;
 
-  // ── 오른쪽 패널: 타이머 + 입력 ──────────────────────────────────────
+  // ── 오른쪽 패널 ─────────────────────────────────────────────────────
   const elapsed = ex?.elapsed_seconds ?? 0;
   let actionBtn;
-  if      (status === 'pending')     actionBtn = `<button class="btn btn-success btn-lg px-5" onclick="doStart()"><i class="bi bi-play-fill me-1"></i>시험시작</button>`;
-  else if (status === 'in_progress') actionBtn = `<button class="btn btn-warning btn-lg px-5" onclick="doPause()"><i class="bi bi-pause-fill me-1"></i>일시정지</button>`;
-  else if (status === 'paused')      actionBtn = `<button class="btn btn-primary btn-lg px-5" onclick="doResume()"><i class="bi bi-play-fill me-1"></i>재시작</button>`;
-  else                               actionBtn = `<span class="fs-5 fw-semibold text-success"><i class="bi bi-check-circle-fill me-2"></i>시험 완료</span>`;
+  if      (status === 'pending')     actionBtn = `<button class="btn btn-success btn-lg px-5" onclick="doStart()"><i class="bi bi-play-fill me-2"></i>시험시작</button>`;
+  else if (status === 'in_progress') actionBtn = `<button class="btn btn-warning btn-lg px-5" onclick="doPause()"><i class="bi bi-pause-fill me-2"></i>일시정지</button>`;
+  else if (status === 'paused')      actionBtn = `<button class="btn btn-primary btn-lg px-5" onclick="doResume()"><i class="bi bi-play-fill me-2"></i>재시작</button>`;
+  else                               actionBtn = `<span class="fs-5 fw-semibold" style="color:#15803d"><i class="bi bi-check-circle-fill me-2"></i>시험 완료</span>`;
 
   const timerColor = status === 'pending' ? '#94a3b8' : '#0f172a';
   const timerSection = `
-  <div class="text-center py-3 mb-2 rounded-3" style="background:${cfg.bg};border-left:4px solid ${cfg.border}">
-    <div id="timer-display" class="font-monospace fw-bold"
-         style="font-size:3.2rem;letter-spacing:.06em;color:${timerColor};line-height:1.1">
-      ${formatElapsed(elapsed)}
+  <div class="exec-timer-card" style="background:${cfg.bg};border:1.5px solid ${cfg.border}">
+    <div class="flex-fill text-center">
+      <div id="timer-display" class="exec-timer-value" style="color:${timerColor}">${formatElapsed(elapsed)}</div>
+      <div class="exec-timer-label">경과 시간</div>
     </div>
-    <div class="text-muted mb-2" style="font-size:.75rem">경과 시간</div>
-    ${actionBtn}
+    <div>${actionBtn}</div>
   </div>`;
 
-  // ── FAIL / BLOCK / PASS ──────────────────────────────────────────────
+  // ── FAIL / BLOCK / PASS ─────────────────────────────────────────────
   let failPassHtml;
   if (status === 'completed') {
     failPassHtml = `
-    <div class="d-flex border rounded-3 overflow-hidden mb-2">
-      <div class="text-center flex-fill py-3 bg-danger bg-opacity-10">
-        <div class="fs-2 fw-bold text-danger">${ex.fail_count}</div>
-        <div class="text-muted small fw-semibold">FAIL</div>
+    <div class="exec-counts-bar mb-3">
+      <div class="exec-count-cell" style="background:#fef2f2">
+        <div class="exec-count-label text-danger">FAIL</div>
+        <div class="exec-count-value text-danger">${ex.fail_count}</div>
       </div>
-      <div class="text-center flex-fill py-3 bg-warning bg-opacity-10 border-start border-end">
-        <div class="fs-2 fw-bold text-warning">${ex.block_count ?? 0}</div>
-        <div class="text-muted small fw-semibold">BLOCK</div>
+      <div class="exec-count-cell" style="background:#fffbeb">
+        <div class="exec-count-label text-warning">BLOCK</div>
+        <div class="exec-count-value text-warning">${ex.block_count ?? 0}</div>
       </div>
-      <div class="text-center flex-fill py-3 bg-success bg-opacity-10 border-end">
-        <div class="fs-2 fw-bold text-success">${ex.pass_count}</div>
-        <div class="text-muted small fw-semibold">PASS</div>
+      <div class="exec-count-cell" style="background:#f0fdf4">
+        <div class="exec-count-label text-success">PASS</div>
+        <div class="exec-count-value text-success">${ex.pass_count}</div>
       </div>
-      <div class="text-center flex-fill py-3 bg-light">
-        <div class="fs-2 fw-bold text-secondary">${ex.total_count}</div>
-        <div class="text-muted small fw-semibold">총 건수</div>
+      <div class="exec-count-cell" style="background:#f8fafc">
+        <div class="exec-count-label text-muted">총 건수</div>
+        <div class="exec-count-value text-secondary">${ex.total_count}</div>
       </div>
     </div>`;
   } else {
@@ -167,28 +169,24 @@ function renderPage() {
     const total  = ex ? ex.total_count     : 0;
     const maxA   = ex ? `max="${total}"`   : '';
     failPassHtml = `
-    <div class="d-flex border rounded-3 overflow-hidden mb-2">
-      <div class="flex-fill text-center p-2 bg-danger bg-opacity-10 border-end">
-        <label class="form-label fw-bold text-danger small mb-1 d-block">FAIL</label>
-        <input type="number" id="fail-input"
-               class="form-control text-center fw-bold text-danger border-danger"
-               style="font-size:1.5rem;max-width:100px;margin:0 auto"
+    <div class="exec-counts-bar mb-3">
+      <div class="exec-count-cell" style="background:#fef2f2">
+        <div class="exec-count-label text-danger">FAIL</div>
+        <input type="number" id="fail-input" class="exec-count-input form-control text-danger border-danger"
                min="0" ${maxA} value="${failV}" ${dis} oninput="updatePass()">
       </div>
-      <div class="flex-fill text-center p-2 bg-warning bg-opacity-10 border-end">
-        <label class="form-label fw-bold text-warning small mb-1 d-block">BLOCK</label>
-        <input type="number" id="block-input"
-               class="form-control text-center fw-bold text-warning border-warning"
-               style="font-size:1.5rem;max-width:100px;margin:0 auto"
+      <div class="exec-count-cell" style="background:#fffbeb">
+        <div class="exec-count-label text-warning">BLOCK</div>
+        <input type="number" id="block-input" class="exec-count-input form-control text-warning border-warning"
                min="0" ${maxA} value="${blockV}" ${dis} oninput="updatePass()">
       </div>
-      <div class="flex-fill text-center p-2 bg-success bg-opacity-10 border-end">
-        <div class="form-label fw-bold text-success small mb-1">PASS</div>
-        <div id="pass-display" class="fw-bold text-success" style="font-size:1.5rem">${passV}</div>
+      <div class="exec-count-cell" style="background:#f0fdf4">
+        <div class="exec-count-label text-success">PASS</div>
+        <div id="pass-display" class="exec-count-value text-success">${passV}</div>
       </div>
-      <div class="flex-fill text-center p-2 bg-light">
-        <div class="form-label fw-semibold text-muted small mb-1">총 건수</div>
-        <div class="fw-bold text-secondary" style="font-size:1.5rem">${total}</div>
+      <div class="exec-count-cell" style="background:#f8fafc">
+        <div class="exec-count-label text-muted">총 건수</div>
+        <div class="exec-count-value text-secondary">${total}</div>
       </div>
     </div>`;
   }
@@ -196,17 +194,21 @@ function renderPage() {
   // ── 수행자 ───────────────────────────────────────────────────────────
   const performerValue = ex ? escHtml(ex.performer || '') : escHtml(_pendingPerformer);
   const performerHtml = `
-  <div class="mb-2">
-    <label class="form-label small fw-semibold mb-1"><i class="bi bi-person-fill me-1"></i>수행자</label>
+  <div class="mb-3">
+    <label class="form-label small fw-semibold text-muted mb-1">
+      <i class="bi bi-person-fill me-1"></i>수행자
+    </label>
     <input type="text" id="performer-input" class="form-control"
       placeholder="시험 수행자 이름…" value="${performerValue}">
   </div>`;
 
-  // ── 코멘트 (남은 공간 채움) ──────────────────────────────────────────
+  // ── 코멘트 ───────────────────────────────────────────────────────────
   const commentValue = ex ? escHtml(ex.comment || '') : escHtml(_pendingComment);
   const commentHtml = `
-  <div class="d-flex flex-column flex-fill mb-2" style="min-height:0">
-    <label class="form-label small fw-semibold mb-1"><i class="bi bi-chat-left-text me-1"></i>코멘트</label>
+  <div class="d-flex flex-column flex-fill mb-3" style="min-height:0">
+    <label class="form-label small fw-semibold text-muted mb-1">
+      <i class="bi bi-chat-left-text me-1"></i>코멘트
+    </label>
     <textarea id="comment-input" class="form-control flex-fill" style="resize:none"
       placeholder="시험 관련 코멘트…">${commentValue}</textarea>
   </div>`;
@@ -219,7 +221,7 @@ function renderPage() {
       <button class="btn btn-outline-secondary" onclick="doReset()">
         <i class="bi bi-arrow-counterclockwise me-1"></i>재시험
       </button>
-      <a href="/execution/" class="btn btn-secondary">
+      <a href="/execution/" class="btn btn-secondary px-4">
         <i class="bi bi-list-ul me-1"></i>목록으로
       </a>
     </div>`;
@@ -230,25 +232,22 @@ function renderPage() {
       <button class="btn btn-outline-secondary" onclick="doReset()" ${dis}>
         <i class="bi bi-arrow-counterclockwise me-1"></i>재시험
       </button>
-      <button class="btn btn-primary px-4" onclick="doComplete()" ${dis}>
+      <button class="btn btn-primary px-5" onclick="doComplete()" ${dis}>
         <i class="bi bi-check-lg me-1"></i>시험완료
       </button>
     </div>`;
   }
 
-  const rightPanel = `
-  <div class="d-flex flex-column flex-fill h-100 overflow-hidden" style="padding:1.25rem 1.25rem 1rem">
-    ${timerSection}
-    ${failPassHtml}
-    ${performerHtml}
-    ${commentHtml}
-    ${footerHtml}
-  </div>`;
-
   document.getElementById('detail-content').innerHTML = `
-  <div class="d-flex h-100 overflow-hidden">
+  <div class="exec-detail-layout">
     ${leftPanel}
-    ${rightPanel}
+    <div class="exec-detail-main">
+      ${timerSection}
+      ${failPassHtml}
+      ${performerHtml}
+      ${commentHtml}
+      ${footerHtml}
+    </div>
   </div>`;
 
   _attachHandlers();

--- a/app/templates/execution/base.html
+++ b/app/templates/execution/base.html
@@ -10,21 +10,25 @@
   {% block head %}{% endblock %}
   <style>
     html, body { height: 100%; overflow: hidden; }
-    body { display: flex; flex-direction: column; }
+    body { display: flex; flex-direction: column; margin: 0; }
     body > main { flex: 1; overflow: hidden; min-height: 0; }
   </style>
 </head>
 <body>
   <div class="exec-toolbar">
-    <div class="exec-toolbar-left">
-      <i class="bi bi-play-circle"></i> 시험 실행
+    <div class="exec-toolbar-brand">
+      <div class="brand-icon"><i class="bi bi-play-fill"></i></div>
+      <div>
+        <div class="brand-title">시험 실행</div>
+        <div class="brand-subtitle">Test Execution System</div>
+      </div>
     </div>
     <div class="exec-toolbar-right">
       {% block toolbar_right %}{% endblock %}
     </div>
   </div>
 
-  <main class="{% block main_class %}container-fluid py-3{% endblock %}">
+  <main class="{% block main_class %}{% endblock %}">
     {% block content %}{% endblock %}
   </main>
 

--- a/app/templates/execution/detail.html
+++ b/app/templates/execution/detail.html
@@ -3,19 +3,22 @@
 
 {% block toolbar_right %}
 <a href="{{ url_for('execution.index') }}" class="btn btn-sm btn-outline-light">
-  <i class="bi bi-arrow-left"></i> 목록
+  <i class="bi bi-arrow-left me-1"></i>목록
 </a>
 <button id="btn-fullscreen" class="btn btn-sm btn-outline-light" title="전체화면">
   <i class="bi bi-fullscreen" id="fullscreen-icon"></i>
 </button>
 {% endblock %}
 
-{% block main_class %}{% endblock %}
+{% block main_class %}h-100 overflow-hidden{% endblock %}
 
 {% block content %}
 <div class="d-flex flex-column h-100">
-  <div class="border-bottom px-4 py-2 bg-white d-flex align-items-center gap-3">
-    <h6 class="mb-0 text-muted" id="page-title">{{ identifier_id }}</h6>
+  <!-- 서브헤더 -->
+  <div style="padding:12px 24px;background:#fff;border-bottom:1px solid #e2e8f0;flex-shrink:0">
+    <h6 class="mb-0 fw-bold text-slate-800" id="page-title" style="color:#1e293b;font-size:1rem">
+      {{ identifier_id }}
+    </h6>
   </div>
   <div id="detail-content" class="flex-fill overflow-hidden">
     <div class="text-center py-5 text-muted">

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -7,71 +7,72 @@
 </button>
 {% endblock %}
 
+{% block main_class %}d-flex flex-column h-100 overflow-hidden{% endblock %}
+
 {% block content %}
-  <!-- 필터 바 -->
-  <div class="d-flex flex-wrap gap-2 mb-2">
-    <select id="filter-date" class="form-select form-select-sm" style="width:auto">
-      <option value="">전체 날짜</option>
-      {% for d in dates %}
-      <option value="{{ d }}">{{ d }}</option>
-      {% endfor %}
-    </select>
-    <select id="filter-location" class="form-select form-select-sm" style="width:auto">
-      <option value="">전체 장소</option>
-      {% for loc in locations %}
-      <option value="{{ loc.id }}">{{ loc.name }}</option>
-      {% endfor %}
-    </select>
-    <input id="search-input" type="search" class="form-control form-control-sm" style="width:220px"
-           placeholder="식별자 / 시험항목 검색...">
-    <button class="btn btn-sm btn-outline-secondary" onclick="loadList()">
-      <i class="bi bi-arrow-clockwise"></i> 새로고침
-    </button>
+<!-- 페이지 헤더 -->
+<div class="exec-page-header">
+  <div class="exec-page-title">
+    <div class="title-icon"><i class="bi bi-list-check"></i></div>
+    시험 실행 목록
+    <span class="exec-item-count" id="item-count"></span>
   </div>
+  <button class="btn btn-sm btn-outline-secondary" onclick="loadList()" title="새로고침">
+    <i class="bi bi-arrow-clockwise"></i>
+  </button>
+</div>
 
-  <!-- 담당자 뱃지 필터 -->
-  <div id="assignee-badges" class="mb-2 d-flex flex-wrap gap-1"></div>
-
-  <!-- 식별자 목록 테이블 -->
-  <div class="table-responsive">
-    <table class="table table-hover table-sm align-middle" id="exec-table">
-      <thead class="table-light">
-        <tr>
-          <th style="width:150px">문서</th>
-          <th style="width:100px">식별자</th>
-          <th>시험항목</th>
-          <th style="width:100px">담당자</th>
-          <th class="sortable" data-sort="location" style="width:90px;cursor:pointer">
-            장소 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
-          </th>
-          <th class="sortable" data-sort="date" style="width:90px;cursor:pointer">
-            날짜 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
-          </th>
-          <th style="width:80px">예상시간</th>
-          <th class="sortable" data-sort="status" style="width:120px;cursor:pointer">
-            상태 <i class="bi bi-arrow-down-up ms-1 text-muted"></i>
-          </th>
-        </tr>
-      </thead>
-      <tbody id="exec-tbody">
-        <tr><td colspan="8" class="text-center text-muted py-4">로딩 중...</td></tr>
-      </tbody>
-    </table>
+<!-- 필터 바 -->
+<div class="exec-filter-bar">
+  <select id="filter-date" class="form-select form-select-sm" style="width:auto">
+    <option value="">전체 날짜</option>
+    {% for d in dates %}
+    <option value="{{ d }}">{{ d }}</option>
+    {% endfor %}
+  </select>
+  <select id="filter-location" class="form-select form-select-sm" style="width:auto">
+    <option value="">전체 장소</option>
+    {% for loc in locations %}
+    <option value="{{ loc.id }}">{{ loc.name }}</option>
+    {% endfor %}
+  </select>
+  <div class="input-group input-group-sm" style="width:220px">
+    <span class="input-group-text bg-white border-end-0" style="border-radius:8px 0 0 8px">
+      <i class="bi bi-search text-muted" style="font-size:.8rem"></i>
+    </span>
+    <input id="search-input" type="search" class="form-control border-start-0" style="border-radius:0 8px 8px 0"
+           placeholder="식별자 / 시험항목 검색…">
   </div>
+</div>
 
-<!-- 실행 모달 -->
-<div class="modal fade" id="execModal" tabindex="-1" aria-labelledby="execModalTitle" aria-hidden="true"
-     data-bs-backdrop="static" data-bs-keyboard="false">
-  <div class="modal-dialog modal-dialog-centered modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="execModalTitle">시험 실행</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body" id="execModalBody">
-      </div>
-    </div>
-  </div>
+<!-- 담당자 뱃지 필터 -->
+<div class="exec-assignee-bar" id="assignee-badges"></div>
+
+<!-- 테이블 -->
+<div class="exec-table-wrapper">
+  <table class="exec-table">
+    <thead>
+      <tr>
+        <th style="width:150px">문서</th>
+        <th style="width:110px">식별자</th>
+        <th>시험항목</th>
+        <th style="width:100px">담당자</th>
+        <th class="sortable" data-sort="location" style="width:90px">
+          장소 <i class="bi bi-arrow-down-up ms-1"></i>
+        </th>
+        <th class="sortable" data-sort="date" style="width:95px">
+          날짜 <i class="bi bi-arrow-down-up ms-1"></i>
+        </th>
+        <th style="width:75px">예상</th>
+        <th class="sortable" data-sort="status" style="width:120px">
+          상태 <i class="bi bi-arrow-down-up ms-1"></i>
+        </th>
+      </tr>
+    </thead>
+    <tbody id="exec-tbody">
+      <tr><td colspan="8" class="text-center text-muted py-5">로딩 중…</td></tr>
+    </tbody>
+  </table>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- **#71** 사이드바 표시 순서: 문서(1행) → 식별자 → 시험항목 → 담당자 → 장소 → 날짜 → 예상시간 → 총건수

### 목록 페이지
- 툴바: 브랜드 아이콘 + "시험 실행 / Test Execution System" 명확한 타이틀
- `exec-page-header`: 페이지 제목 + 항목 수 표시
- `exec-filter-bar`: 통합 필터 컨테이너
- 테이블 행에 상태별 왼쪽 컬러 강조선 (진행=파랑, 정지=노랑, 완료=초록)
- 상태 배지: 점 + 텍스트 인라인 배지로 교체

### 상세 페이지
- 사이드바: `exec-detail-sidebar` 전용 클래스, 라벨-값 구조 개선
- 타이머 카드: `exec-timer-card` 상태 색상 경계선
- FAIL/BLOCK/PASS: `exec-counts-bar` 카드 스타일

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)