### PR TITLE
fix(execution): 담당자 필터 드롭다운 전환 및 여백 개선 (#72, #73)

### DIFF
--- a/app/static/execution/css/style.css
+++ b/app/static/execution/css/style.css
@@ -61,7 +61,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px 12px;
+  padding: 20px 28px 16px;
   border-bottom: 1px solid var(--exec-border);
   background: #fff;
 }
@@ -93,12 +93,12 @@
 
 /* ─── 필터 바 ──────────────────────────────────────────────────────────── */
 .exec-filter-bar {
-  padding: 12px 24px;
+  padding: 14px 28px;
   background: #f8fafc;
   border-bottom: 1px solid var(--exec-border);
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
   align-items: center;
 }
 .exec-filter-bar .form-select,
@@ -163,7 +163,7 @@
   top: 0;
   background: #f8fafc;
   border-bottom: 2px solid var(--exec-border);
-  padding: 10px 14px;
+  padding: 12px 18px;
   font-size: .75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -182,7 +182,7 @@
 }
 .exec-table tbody tr:hover { background: #f8fafc; }
 .exec-table tbody td {
-  padding: 10px 14px;
+  padding: 13px 18px;
   vertical-align: middle;
   color: #334155;
 }

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -4,7 +4,6 @@ let _currentItem = null;
 let _allItems = [];
 let _sortCol = null;
 let _sortDir = 'asc';
-let _activeAssignees = new Set();
 let _searchText = '';
 let _pendingComment = '';  // 시험 시작 전 미리 입력된 코멘트
 
@@ -84,7 +83,7 @@ async function loadList() {
 
   try {
     _allItems = await apiFetch('/execution/api/list?' + params.toString());
-    renderAssigneeBadges();
+    renderAssigneeDropdown();
     applyAndRender();
   } catch {
     document.getElementById('exec-tbody').innerHTML =
@@ -92,26 +91,19 @@ async function loadList() {
   }
 }
 
-// ── 담당자 뱃지 필터 ───────────────────────────────────────────────────────
+// ── 담당자 드롭다운 필터 (#73) ────────────────────────────────────────────
 
-function renderAssigneeBadges() {
-  const container = document.getElementById('assignee-badges');
+function renderAssigneeDropdown() {
+  const sel = document.getElementById('filter-assignee');
+  if (!sel) return;
   const all = new Set();
   _allItems.forEach(item => (item.assignee_names || []).forEach(a => all.add(a)));
-  if (!all.size) { container.innerHTML = ''; return; }
-  container.innerHTML = [...all].sort().map(a => {
-    const esc = escHtml(a);
-    const active = _activeAssignees.has(esc);
-    return `<span class="exec-assignee-badge ${active ? 'active' : ''}"
-      onclick="toggleAssignee(${JSON.stringify(esc)})">${esc}</span>`;
-  }).join('');
-}
-
-function toggleAssignee(name) {
-  if (_activeAssignees.has(name)) _activeAssignees.delete(name);
-  else _activeAssignees.add(name);
-  renderAssigneeBadges();
-  applyAndRender();
+  const current = sel.value;
+  sel.innerHTML = '<option value="">전체 담당자</option>' +
+    [...all].sort().map(a => {
+      const esc = escHtml(a);
+      return `<option value="${esc}" ${current === esc ? 'selected' : ''}>${esc}</option>`;
+    }).join('');
 }
 
 // ── 정렬 ──────────────────────────────────────────────────────────────────
@@ -135,8 +127,9 @@ function applyAndRender() {
   const q = _searchText.toLowerCase();
   if (q) items = items.filter(i =>
     i.identifier_id.toLowerCase().includes(q) || i.identifier_name.toLowerCase().includes(q));
-  if (_activeAssignees.size)
-    items = items.filter(i => (i.assignee_names || []).some(a => _activeAssignees.has(escHtml(a))));
+  const assigneeFilter = document.getElementById('filter-assignee')?.value || '';
+  if (assigneeFilter)
+    items = items.filter(i => (i.assignee_names || []).some(a => escHtml(a) === assigneeFilter));
   if (_sortCol) {
     items.sort((a, b) => {
       let va, vb;
@@ -473,6 +466,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btn-fullscreen').addEventListener('click', toggleFullscreen);
   document.getElementById('filter-date').addEventListener('change', loadList);
   document.getElementById('filter-location').addEventListener('change', loadList);
+  document.getElementById('filter-assignee').addEventListener('change', applyAndRender);
   document.getElementById('search-input').addEventListener('input', e => {
     _searchText = e.target.value.trim();
     applyAndRender();

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -36,6 +36,9 @@
     <option value="{{ loc.id }}">{{ loc.name }}</option>
     {% endfor %}
   </select>
+  <select id="filter-assignee" class="form-select form-select-sm" style="width:auto">
+    <option value="">전체 담당자</option>
+  </select>
   <div class="input-group input-group-sm" style="width:220px">
     <span class="input-group-text bg-white border-end-0" style="border-radius:8px 0 0 8px">
       <i class="bi bi-search text-muted" style="font-size:.8rem"></i>
@@ -44,9 +47,6 @@
            placeholder="식별자 / 시험항목 검색…">
   </div>
 </div>
-
-<!-- 담당자 뱃지 필터 -->
-<div class="exec-assignee-bar" id="assignee-badges"></div>
 
 <!-- 테이블 -->
 <div class="exec-table-wrapper">


### PR DESCRIPTION
## Summary
- **#73** 담당자 필터: 뱃지 토글 → `<select>` 드롭다운으로 교체 (목록 데이터 기반 자동 생성)
- **#72** 여백: 페이지 헤더·필터바 패딩 확대, 테이블 행 패딩 10px→13px

Closes #72, #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)