### PR TITLE
feat(execution): 바코드 식별자 Prefix 설정 추가 (#82)

### DIFF
--- a/app/features/execution/barcode_config.py
+++ b/app/features/execution/barcode_config.py
@@ -1,0 +1,4 @@
+# 바코드 식별자 Prefix 설정
+# 바코드 입력: OPEN|TC|011  →  실제 식별자: {IDENTIFIER_PREFIX}TC-011
+# 예) IDENTIFIER_PREFIX = 'A-BCD-'  →  A-BCD-TC-011
+IDENTIFIER_PREFIX = ''

--- a/app/features/execution/routes/views.py
+++ b/app/features/execution/routes/views.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template
 
+from app.features.execution.barcode_config import IDENTIFIER_PREFIX
 from app.features.schedule.models import location as loc_repo
 from app.features.schedule.models import schedule_block as block_repo
 
@@ -10,7 +11,7 @@ def _index_context():
     locations = loc_repo.get_all()
     blocks = block_repo.get_all()
     dates = sorted({b['date'] for b in blocks if b.get('date')})
-    return dict(locations=locations, dates=dates)
+    return dict(locations=locations, dates=dates, barcode_prefix=IDENTIFIER_PREFIX)
 
 
 @views_bp.route('/')
@@ -20,4 +21,5 @@ def index():
 
 @views_bp.route('/<identifier_id>')
 def detail(identifier_id):
-    return render_template('execution/detail.html', identifier_id=identifier_id)
+    return render_template('execution/detail.html', identifier_id=identifier_id,
+                           barcode_prefix=IDENTIFIER_PREFIX)

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -186,7 +186,7 @@ function _initBarcodeListener(onScan) {
 // 바코드 코드에서 식별자 추출: OPEN|TC|001 → TC-001
 function _barcodeToId(code) {
   const parts = code.split('|');
-  return parts.slice(1).join('-');
+  return (typeof BARCODE_PREFIX !== 'undefined' ? BARCODE_PREFIX : '') + parts.slice(1).join('-');
 }
 
 // ── 초기화 ────────────────────────────────────────────────────────────────

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -406,7 +406,7 @@ function _initBarcodeListener(onScan) {
 
 function _barcodeToId(code) {
   const parts = code.split('|');
-  return parts.slice(1).join('-');
+  return (typeof BARCODE_PREFIX !== 'undefined' ? BARCODE_PREFIX : '') + parts.slice(1).join('-');
 }
 
 function _tryAutoStart() {

--- a/app/templates/execution/detail.html
+++ b/app/templates/execution/detail.html
@@ -29,6 +29,9 @@
 {% endblock %}
 
 {% block scripts %}
-<script>var IDENTIFIER_ID = {{ identifier_id | tojson }};</script>
+<script>
+  var IDENTIFIER_ID = {{ identifier_id | tojson }};
+  var BARCODE_PREFIX = {{ barcode_prefix | tojson }};
+</script>
 <script src="{{ url_for('static', filename='execution/js/execution-detail.js') }}?v={{ cache_bust }}"></script>
 {% endblock %}

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -77,5 +77,6 @@
 {% endblock %}
 
 {% block scripts %}
+<script>var BARCODE_PREFIX = {{ barcode_prefix | tojson }};</script>
 <script src="{{ url_for('static', filename='execution/js/execution-app.js') }}?v={{ cache_bust }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- `app/features/execution/barcode_config.py` 에 `IDENTIFIER_PREFIX` 변수 추가
- `OPEN|TC|011` → `{IDENTIFIER_PREFIX}TC-011` 으로 변환
- 예) `IDENTIFIER_PREFIX = 'A-BCD-'` 설정 시 `OPEN|TC|011` → `/execution/A-BCD-TC-011`

## 설정 방법
```python
# app/features/execution/barcode_config.py
IDENTIFIER_PREFIX = 'A-BCD-'  # 원하는 prefix로 수정
```

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)