### PR TITLE
fix(barcode): 바코드 구분자 | → - 변경 (#84)

### DIFF
--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -183,9 +183,9 @@ function _initBarcodeListener(onScan) {
   });
 }
 
-// 바코드 코드에서 식별자 추출: OPEN|TC|001 → TC-001
+// 바코드 코드에서 식별자 추출: OPEN-TC-001 → TC-001
 function _barcodeToId(code) {
-  const parts = code.split('|');
+  const parts = code.split('-');
   return (typeof BARCODE_PREFIX !== 'undefined' ? BARCODE_PREFIX : '') + parts.slice(1).join('-');
 }
 
@@ -221,7 +221,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 바코드 OPEN 명령 감지 (#78)
   _initBarcodeListener(code => {
-    if (code.startsWith('OPEN|')) {
+    if (code.startsWith('OPEN-')) {
       const identifierId = _barcodeToId(code);
       window.location.href = `/execution/${encodeURIComponent(identifierId)}?autostart=1`;
     }

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -396,7 +396,7 @@ function _initBarcodeListener(onScan) {
       if (code) onScan(code);
       return;
     }
-    if (/^[A-Z0-9|]$/.test(e.key)) {
+    if (/^[A-Z0-9-]$/.test(e.key)) {
       buf += e.key;
       clearTimeout(timer);
       timer = setTimeout(() => { buf = ''; }, 80);
@@ -405,7 +405,7 @@ function _initBarcodeListener(onScan) {
 }
 
 function _barcodeToId(code) {
-  const parts = code.split('|');
+  const parts = code.split('-');
   return (typeof BARCODE_PREFIX !== 'undefined' ? BARCODE_PREFIX : '') + parts.slice(1).join('-');
 }
 
@@ -451,7 +451,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   _initBarcodeListener(code => {
     if (code === 'TERMINATE') {
       if (_item?.execution?.status === 'in_progress') doPause();
-    } else if (code.startsWith('OPEN|')) {
+    } else if (code.startsWith('OPEN-')) {
       const identifierId = _barcodeToId(code);
       if (identifierId === IDENTIFIER_ID) {
         _tryAutoStart();


### PR DESCRIPTION
## Summary
- 바코드 포맷 변경: `OPEN|TC|001` → `OPEN-TC-001`
- `execution-app.js`, `execution-detail.js` 두 파일 모두 적용
- 정규식, `startsWith`, `split` 구분자 모두 `|` → `-`로 통일

## Test plan
- [ ] 바코드 스캔 시 `OPEN-TC-001` 포맷으로 동작 확인
- [ ] 목록 페이지에서 OPEN 스캔 → 해당 항목 자동이동 확인
- [ ] 상세 페이지에서 OPEN 스캔 → 자동시작 또는 네비게이션 확인

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)