### PR TITLE
fix(barcode): 문자 수집 정규식 | → - 누락 수정

### DIFF
--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -175,7 +175,7 @@ function _initBarcodeListener(onScan) {
       if (code) onScan(code);
       return;
     }
-    if (/^[A-Z0-9|]$/.test(e.key)) {
+    if (/^[A-Z0-9-]$/.test(e.key)) {
       buf += e.key;
       clearTimeout(timer);
       timer = setTimeout(() => { buf = ''; }, 80);


### PR DESCRIPTION
## Summary
- 이전 #84 커밋에서 `startsWith`, `split`은 변경했으나 키 입력 필터 정규식 `/^[A-Z0-9|]$/` → `/^[A-Z0-9-]$/` 누락
- 정규식에 `-`가 없어서 바코드의 `-` 문자가 버퍼에 쌓이지 않아 `OPENTC001` 형태로 인식 → `OPEN-` 체크 실패로 이동 안 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)