### PR TITLE
fix(execution): 이슈 #88 #89 #90 처리

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, session
 
 from app.features.execution.models.execution import ExecutionRepository
 
@@ -113,6 +113,21 @@ def total_count(identifier_id):
     return jsonify({'total_count': _get_total_count(identifier_id)})
 
 
+@api_bp.route('/whoami')
+def whoami():
+    return jsonify({'username': session.get('username', '')})
+
+
+@api_bp.route('/login', methods=['POST'])
+def login():
+    body = request.get_json(silent=True) or {}
+    username = body.get('username', '').strip()
+    if not username:
+        return jsonify({'error': 'username required'}), 400
+    session['username'] = username
+    return jsonify({'username': username})
+
+
 @api_bp.route('/start', methods=['POST'])
 def start():
     body = request.get_json(silent=True) or {}
@@ -120,8 +135,27 @@ def start():
     task_id = body.get('task_id', '').strip()
     if not identifier_id or not task_id:
         return jsonify({'error': 'identifier_id and task_id required'}), 400
+
+    current_user = session.get('username', '')
+    if current_user:
+        for ex in ExecutionRepository.get_all():
+            if ex.get('status') != 'in_progress':
+                continue
+            if ex.get('identifier_id') == identifier_id:
+                continue
+            performer = ex.get('performer', '')
+            if performer == current_user:
+                return jsonify({'error': '이미 진행 중인 시험이 있습니다.', 'code': 'user_busy'}), 409
+            if performer:
+                return jsonify({'error': f'"{performer}"님이 시험을 진행 중입니다.', 'code': 'another_user_busy'}), 409
+
     total = _get_total_count(identifier_id)
     ex = ExecutionRepository.start(identifier_id, task_id, total_count=total)
+
+    if ex and current_user and not ex.get('performer'):
+        ExecutionRepository.update_performer(ex['id'], current_user)
+        ex['performer'] = current_user
+
     return jsonify(ex), 201
 
 

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -3,6 +3,69 @@
 let _item = null;
 let _pendingComment = '';
 let _pendingPerformer = '';
+let _currentUser = '';
+
+// ── 사용자 모달 ───────────────────────────────────────────────────────────
+
+function openUserModal() {
+  const modal = new bootstrap.Modal(document.getElementById('userModal'));
+  const input = document.getElementById('user-modal-input');
+  const list  = document.getElementById('user-modal-list');
+  if (input) input.value = _currentUser;
+  if (list)  list.innerHTML = '<div class="text-muted small p-2">로딩 중…</div>';
+  modal.show();
+
+  fetch('/admin/api/users')
+    .then(r => r.json())
+    .then(users => {
+      if (!list) return;
+      if (!users.length) { list.innerHTML = '<div class="text-muted small p-2">등록된 사용자 없음</div>'; return; }
+      list.innerHTML = users.map(u =>
+        `<button type="button" class="list-group-item list-group-item-action py-1 px-2 small"
+           onclick="selectUserFromList(${JSON.stringify(u.name)})">${escHtml(u.name)}</button>`
+      ).join('');
+    })
+    .catch(() => { if (list) list.innerHTML = '<div class="text-muted small p-2">불러오기 실패</div>'; });
+}
+
+function selectUserFromList(name) {
+  const input = document.getElementById('user-modal-input');
+  if (input) input.value = name;
+}
+
+async function applyUserFromModal() {
+  const input = document.getElementById('user-modal-input');
+  const name = input ? input.value.trim() : '';
+  if (!name) return;
+
+  await apiFetch('/execution/api/login', 'POST', { username: name });
+  _currentUser = name;
+  localStorage.setItem('execution_quick_user', name);
+  _updateToolbarUser();
+
+  const performer = document.getElementById('performer-input');
+  if (performer) {
+    performer.value = name;
+    performer.dispatchEvent(new Event('change'));
+  }
+
+  bootstrap.Modal.getInstance(document.getElementById('userModal'))?.hide();
+}
+
+function _updateToolbarUser() {
+  const el = document.getElementById('toolbar-username');
+  if (el) el.textContent = _currentUser || '(미설정)';
+}
+
+function doQuickAssign() {
+  const cached = localStorage.getItem('execution_quick_user') || '';
+  if (!cached) { openUserModal(); return; }
+  const performer = document.getElementById('performer-input');
+  if (performer) {
+    performer.value = cached;
+    performer.dispatchEvent(new Event('change'));
+  }
+}
 
 // 타이머
 let _timerInterval = null;
@@ -202,14 +265,23 @@ function renderPage() {
   }
 
   // ── 수행자 ───────────────────────────────────────────────────────────
-  const performerValue = ex ? escHtml(ex.performer || '') : escHtml(_pendingPerformer);
+  const rawPerformer = ex ? (ex.performer || '') : _pendingPerformer;
+  const performerValue = escHtml(rawPerformer || _currentUser);
   const performerHtml = `
   <div class="mb-3">
     <label class="form-label small fw-semibold text-muted mb-1">
       <i class="bi bi-person-fill me-1"></i>수행자
     </label>
-    <input type="text" id="performer-input" class="form-control"
-      placeholder="시험 수행자 이름…" value="${performerValue}">
+    <div class="input-group">
+      <input type="text" id="performer-input" class="form-control"
+        placeholder="시험 수행자 이름…" value="${performerValue}">
+      <button type="button" class="btn btn-outline-secondary btn-sm" onclick="doQuickAssign()" title="저장된 이름 빠른 할당">
+        <i class="bi bi-lightning-fill"></i>
+      </button>
+      <button type="button" class="btn btn-outline-secondary btn-sm" onclick="openUserModal()" title="사용자 선택">
+        <i class="bi bi-person-lines-fill"></i>
+      </button>
+    </div>
   </div>`;
 
   // ── 코멘트 ───────────────────────────────────────────────────────────
@@ -229,7 +301,7 @@ function renderPage() {
     footerHtml = `
     <div class="d-flex justify-content-between gap-2">
       <button class="btn btn-outline-secondary" onclick="doReset()">
-        <i class="bi bi-arrow-counterclockwise me-1"></i>재시험
+        <i class="bi bi-arrow-counterclockwise me-1"></i>초기화
       </button>
       <div class="d-flex gap-2">
         <button id="btn-save-comment" class="btn btn-outline-success" onclick="doSaveComment()" disabled>
@@ -245,7 +317,7 @@ function renderPage() {
     footerHtml = `
     <div class="d-flex justify-content-between gap-2">
       <button class="btn btn-outline-secondary" onclick="doReset()" ${dis}>
-        <i class="bi bi-arrow-counterclockwise me-1"></i>재시험
+        <i class="bi bi-arrow-counterclockwise me-1"></i>초기화
       </button>
       <div class="d-flex gap-2">
         <button id="btn-save-comment" class="btn btn-outline-success" onclick="doSaveComment()" disabled>
@@ -349,17 +421,26 @@ async function doStart() {
   if (pi) _pendingPerformer = pi.value;
 
   try {
-    const ex = await apiFetch('/execution/api/start', 'POST', {
-      identifier_id: _item.identifier_id, task_id: _item.task_id,
+    const resp = await fetch('/execution/api/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier_id: _item.identifier_id, task_id: _item.task_id }),
     });
+    if (resp.status === 409) {
+      const err = await resp.json();
+      alert(err.error || '시험을 시작할 수 없습니다.');
+      return;
+    }
+    if (!resp.ok) throw new Error(`API error ${resp.status}`);
+    const ex = await resp.json();
     _item.execution = {
       id: ex.id, status: ex.status, elapsed_seconds: 0,
       total_count: ex.total_count, fail_count: 0, block_count: 0, pass_count: 0,
-      comment: _pendingComment, performer: _pendingPerformer,
+      comment: _pendingComment, performer: ex.performer || _pendingPerformer,
     };
     const saves = [];
     if (_pendingComment)   saves.push(apiFetch('/execution/api/comment', 'PUT', { execution_id: ex.id, comment: _pendingComment }));
-    if (_pendingPerformer) saves.push(apiFetch('/execution/api/performer', 'PUT', { execution_id: ex.id, performer: _pendingPerformer }));
+    if (_pendingPerformer && !ex.performer) saves.push(apiFetch('/execution/api/performer', 'PUT', { execution_id: ex.id, performer: _pendingPerformer }));
     await Promise.all(saves);
     _pendingComment = ''; _pendingPerformer = '';
     renderPage();
@@ -403,7 +484,7 @@ async function doComplete() {
 
 async function doReset() {
   if (!_item?.execution?.id) return;
-  if (!confirm('재시험하면 현재 기록이 초기화됩니다. 계속할까요?')) return;
+  if (!confirm('초기화하면 현재 기록이 삭제됩니다. 계속할까요?')) return;
   try {
     await apiFetch('/execution/api/reset', 'POST', { execution_id: _item.execution.id });
     stopLocalTimer();
@@ -464,6 +545,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   // 전체화면 버튼
   document.getElementById('btn-fullscreen').addEventListener('click', toggleFullscreen);
 
+  // 현재 사용자 로드
+  try {
+    const who = await apiFetch('/execution/api/whoami');
+    _currentUser = who.username || localStorage.getItem('execution_quick_user') || '';
+    _updateToolbarUser();
+  } catch { /* 무시 */ }
 
   try {
     _item = await apiFetch(`/execution/api/item/${encodeURIComponent(IDENTIFIER_ID)}`);

--- a/app/templates/execution/base.html
+++ b/app/templates/execution/base.html
@@ -24,7 +24,33 @@
       </div>
     </div>
     <div class="exec-toolbar-right">
+      <button id="toolbar-user-btn" class="btn btn-sm btn-outline-light me-2" onclick="openUserModal()" title="사용자 변경">
+        <i class="bi bi-person-circle me-1"></i><span id="toolbar-username">…</span>
+      </button>
       {% block toolbar_right %}{% endblock %}
+    </div>
+  </div>
+
+  <!-- 사용자 선택 모달 -->
+  <div class="modal fade" id="userModal" tabindex="-1" aria-labelledby="userModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header py-2">
+          <h6 class="modal-title" id="userModalLabel"><i class="bi bi-person-fill me-1"></i>사용자 선택</h6>
+          <button type="button" class="btn-close btn-close-sm" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body p-2">
+          <div class="mb-2">
+            <input type="text" id="user-modal-input" class="form-control form-control-sm" placeholder="이름 직접 입력…">
+          </div>
+          <div id="user-modal-list" class="list-group list-group-flush"></div>
+        </div>
+        <div class="modal-footer py-2">
+          <button type="button" class="btn btn-primary btn-sm w-100" onclick="applyUserFromModal()">
+            <i class="bi bi-check-lg me-1"></i>선택
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- **#88** `재시험` 버튼을 `초기화`로 명칭 변경 (완료/미완료 상태 모두, 확인 다이얼로그 메시지도 동일하게 변경)
- **#89** 수행자 입력 UX 개선
  - 페이지 로드 시 세션 사용자(`session.get('username')`)로 자동 채우기
  - `⚡` 빠른 할당 버튼 — localStorage에 캐시된 이름을 즉시 할당
  - `👤` 사용자 선택 버튼 — 등록된 사용자 목록 팝업 모달, 직접 입력도 가능
  - 선택 시 세션 저장(`/execution/api/login`) + localStorage 캐시 동시 갱신
  - 툴바 우측에 현재 사용자 표시 및 클릭으로 변경 가능
- **#90** 동시 시험 차단
  - 동일 사용자가 진행 중인 다른 시험 있으면 시작 불가
  - 타 사용자가 시험 중이면 시작 불가 (글로벌 1건 제한)
  - 시험 시작 시 세션 사용자를 수행자로 자동 설정
  - 409 응답 시 프론트엔드에서 명확한 에러 메시지 표시

## Test plan

- [ ] 시험 수행 상세 페이지에서 "재시험" 버튼이 "초기화"로 표시되는지 확인
- [ ] 사용자 미설정 상태에서 `👤` 버튼으로 사용자 선택 → 수행자 자동 입력 확인
- [ ] `⚡` 버튼으로 localStorage 캐시된 이름 즉시 할당 확인
- [ ] 툴바에 현재 사용자 이름 표시 확인
- [ ] 사용자 A가 진행 중일 때 동일 사용자가 다른 시험 시작 시 에러 메시지 확인
- [ ] 사용자 A가 진행 중일 때 사용자 B가 시험 시작 시 에러 메시지 확인

Closes #88, #89, #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)