### PR TITLE
fix(execution): 시험 시작 전 코멘트를 executions.json에 저장

### DIFF
--- a/app/features/execution/models/execution.py
+++ b/app/features/execution/models/execution.py
@@ -137,6 +137,36 @@ class ExecutionRepository:
         return cls._patch(execution_id, performer=performer)
 
     @classmethod
+    def save_pre_comment(cls, identifier_id, task_id, comment):
+        """시험 시작 전 코멘트를 pending 상태 실행 레코드로 저장한다."""
+        existing = cls.get_by_identifier(identifier_id)
+        if existing:
+            if existing['status'] == 'pending':
+                return cls._patch(existing['id'], comment=comment)
+            return existing  # 이미 진행 중 — 덮어쓰지 않음
+        now = datetime.now().isoformat(timespec='seconds')
+        data = {
+            'id': generate_id(ID_PREFIX),
+            'identifier_id': identifier_id,
+            'task_id': task_id,
+            'status': 'pending',
+            'segments': [],
+            'total_count': 0,
+            'fail_count': 0,
+            'block_count': 0,
+            'pass_count': 0,
+            'comment': comment,
+            'performer': '',
+            'created_at': now,
+            'completed_at': None,
+            'elapsed_seconds': 0,
+        }
+        items = read_json(FILENAME)
+        items.append(data)
+        write_json(FILENAME, items)
+        return data
+
+    @classmethod
     def reset(cls, execution_id):
         return cls._patch(
             execution_id,

--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -236,6 +236,18 @@ def complete():
     return jsonify(ex)
 
 
+@api_bp.route('/pending-comment', methods=['PUT'])
+def pending_comment():
+    body = request.get_json(silent=True) or {}
+    identifier_id = body.get('identifier_id', '').strip()
+    task_id = body.get('task_id', '').strip()
+    comment = body.get('comment', '')
+    if not identifier_id or not task_id:
+        return jsonify({'error': 'identifier_id and task_id required'}), 400
+    ExecutionRepository.save_pre_comment(identifier_id, task_id, comment)
+    return jsonify({'ok': True})
+
+
 @api_bp.route('/comment', methods=['PUT'])
 def update_comment():
     body = request.get_json(silent=True) or {}

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -125,6 +125,10 @@ function stopLocalTimer() {
 
 // ── 렌더링 (#62 리디자인) ─────────────────────────────────────────────────
 
+function _isStarted(ex) {
+  return ex && ex.status !== 'pending';
+}
+
 function renderPage() {
   const item   = _item;
   const ex     = item.execution;
@@ -217,12 +221,13 @@ function renderPage() {
       </div>
     </div>`;
   } else {
-    const dis    = !ex ? 'disabled' : '';
-    const failV  = ex ? ex.fail_count      : 0;
-    const blockV = ex ? (ex.block_count ?? 0) : 0;
-    const passV  = ex ? ex.pass_count      : 0;
-    const total  = ex ? ex.total_count     : 0;
-    const maxA   = ex ? `max="${total}"`   : '';
+    const started = _isStarted(ex);
+    const dis    = !started ? 'disabled' : '';
+    const failV  = started ? ex.fail_count      : 0;
+    const blockV = started ? (ex.block_count ?? 0) : 0;
+    const passV  = started ? ex.pass_count      : 0;
+    const total  = started ? ex.total_count     : 0;
+    const maxA   = started ? `max="${total}"`   : '';
     failPassHtml = `
     <div class="exec-counts-bar mb-3">
       <div class="exec-count-cell" style="background:#fef2f2">
@@ -247,7 +252,7 @@ function renderPage() {
   }
 
   // ── 수행자 ───────────────────────────────────────────────────────────
-  const rawPerformer = ex ? (ex.performer || '') : _pendingPerformer;
+  const rawPerformer = _isStarted(ex) ? (ex.performer || '') : _pendingPerformer;
   const performerValue = escHtml(rawPerformer || _currentUser);
   const performerHtml = `
   <div class="mb-3">
@@ -267,7 +272,7 @@ function renderPage() {
   </div>`;
 
   // ── 코멘트 ───────────────────────────────────────────────────────────
-  const commentValue = ex ? escHtml(ex.comment || '') : escHtml(_pendingComment);
+  const commentValue = escHtml(ex?.comment || _pendingComment);
   const commentHtml = `
   <div class="d-flex flex-column flex-fill mb-3" style="min-height:0">
     <label class="form-label small fw-semibold text-muted mb-1">
@@ -295,7 +300,8 @@ function renderPage() {
       </div>
     </div>`;
   } else {
-    const dis = !ex ? 'disabled' : '';
+    const started = _isStarted(ex);
+    const dis = !started ? 'disabled' : '';
     footerHtml = `
     <div class="d-flex justify-content-between gap-2">
       <button class="btn btn-outline-secondary" onclick="doReset()" ${dis}>
@@ -335,9 +341,9 @@ function _attachHandlers() {
   const ta = document.getElementById('comment-input');
   const saveBtn = document.getElementById('btn-save-comment');
   if (ta && saveBtn) {
-    const savedValue = ta.value;
     ta.addEventListener('input', () => {
-      const changed = ta.value !== (_item?.execution?.comment || '');
+      const saved = _item?.execution?.comment || _pendingComment;
+      const changed = ta.value !== saved;
       saveBtn.classList.toggle('btn-save-changed', changed);
       saveBtn.disabled = !changed;
     });
@@ -347,7 +353,7 @@ function _attachHandlers() {
   const pi = document.getElementById('performer-input');
   if (pi) {
     const savePerformer = async () => {
-      if (!_item?.execution?.id) { _pendingPerformer = pi.value; return; }
+      if (!_isStarted(_item?.execution)) { _pendingPerformer = pi.value; return; }
       try {
         await apiFetch('/execution/api/performer', 'PUT', {
           execution_id: _item.execution.id, performer: pi.value,
@@ -395,8 +401,14 @@ async function doSaveComment() {
   const saveBtn = document.getElementById('btn-save-comment');
   if (!ta) return;
 
-  if (!_item?.execution?.id) {
+  if (!_isStarted(_item?.execution)) {
     _savePendingComment(ta.value);
+    try {
+      await apiFetch('/execution/api/pending-comment', 'PUT', {
+        identifier_id: _item.identifier_id, task_id: _item.task_id, comment: ta.value,
+      });
+      if (_item.execution) _item.execution.comment = ta.value;
+    } catch { /* localStorage에는 이미 저장됨 */ }
     if (saveBtn) _showSaveFeedback(saveBtn);
     return;
   }
@@ -563,7 +575,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   try {
     _item = await apiFetch(`/execution/api/item/${encodeURIComponent(IDENTIFIER_ID)}`);
-    if (!_item.execution) _pendingComment = _loadPendingComment();
+    if (!_isStarted(_item.execution)) {
+      _pendingComment = _item.execution?.comment || _loadPendingComment();
+    }
     renderPage();
     // ?autostart=1 파라미터로 진입 시 자동시작 (#78)
     if (new URLSearchParams(window.location.search).get('autostart') === '1') {


### PR DESCRIPTION
## Summary

- 시험 미시작 상태에서 코멘트 저장 버튼 클릭 시 `executions.json`에 `pending` 상태 레코드로 저장되도록 수정
- 기존에는 localStorage에만 저장되어 서버 파일에 반영되지 않는 문제 수정

## 변경 내용

- `ExecutionRepository.save_pre_comment()`: `identifier_id`에 해당하는 실행 레코드가 없으면 `pending` 상태로 생성, 이미 있으면 comment만 업데이트
- `PUT /execution/api/pending-comment` 엔드포인트 추가
- `_isStarted(ex)` 헬퍼: `pending` 상태를 미시작으로 취급 (FAIL/BLOCK/PASS 입력, 시험완료 버튼 비활성화)
- 시험 시작 시 기존 `pending` 레코드가 `in_progress`로 업그레이드되며 코멘트 유지

## Test plan

- [ ] 시험 미시작 상태에서 코멘트 입력 후 저장 → `executions.json`에 `pending` 레코드 생성 확인
- [ ] 페이지 새로고침 후 코멘트가 유지되는지 확인
- [ ] 시험 시작 후 `pending` 레코드가 `in_progress`로 변경되고 코멘트가 보존되는지 확인
- [ ] `pending` 상태에서 FAIL/BLOCK/PASS 입력 및 시험완료 버튼이 비활성화 상태인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)