### PR TITLE
fix(execution): 재시험 실행 레코드·코멘트 독립 관리 (#118)

### DIFF
--- a/app/features/execution/models/execution.py
+++ b/app/features/execution/models/execution.py
@@ -246,8 +246,10 @@ class ExecutionRepository:
         - pending 상태의 레코드가 있으면: 코멘트만 갱신
         - 이미 진행 중이거나 완료된 레코드면: 덮어쓰지 않고 기존 레코드 반환
           (진행 중 코멘트 변경은 /comment 엔드포인트를 사용해야 함)
+
+        task_id로 정확히 조회하여 재시험(동일 identifier, 다른 task)과 혼용되지 않게 한다.
         """
-        existing = cls.get_by_identifier(identifier_id)
+        existing = cls.get_by_identifier_and_task(identifier_id, task_id)
         if existing:
             if existing['status'] == 'pending':
                 return cls._patch(existing['id'], comment=comment)

--- a/app/features/execution/routes/views.py
+++ b/app/features/execution/routes/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request
 
 from app.features.execution.barcode_config import IDENTIFIER_PREFIX
 from app.features.schedule.models import location as loc_repo
@@ -21,5 +21,7 @@ def index():
 
 @views_bp.route('/<identifier_id>')
 def detail(identifier_id):
+    task_id = request.args.get('task_id', '')
     return render_template('execution/detail.html', identifier_id=identifier_id,
+                           task_id=task_id,
                            barcode_prefix=IDENTIFIER_PREFIX)

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -425,7 +425,8 @@ function renderTable(items) {
   tbody.querySelectorAll('tr').forEach(tr =>
     tr.addEventListener('click', () => {
       const item = JSON.parse(tr.dataset.item);
-      window.location.href = `/execution/${encodeURIComponent(item.identifier_id)}`;
+      const taskParam = item.task_id ? `?task_id=${encodeURIComponent(item.task_id)}` : '';
+      window.location.href = `/execution/${encodeURIComponent(item.identifier_id)}${taskParam}`;
     }));
 
   // 코멘트 아이콘(💬)의 Bootstrap Tooltip 초기화

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -498,10 +498,12 @@ function _attachHandlers() {
 
 /**
  * 식별자별 localStorage 키를 반환한다.
- * IDENTIFIER_ID가 없는 환경(테스트 등)에서도 충돌하지 않도록 빈 문자열을 허용한다.
+ * TASK_ID를 포함해 원본/재시험이 같은 identifier_id를 가져도 충돌하지 않는다.
  */
 function _pendingCommentKey() {
-  return `pending_comment_${typeof IDENTIFIER_ID !== 'undefined' ? IDENTIFIER_ID : ''}`;
+  const iid = typeof IDENTIFIER_ID !== 'undefined' ? IDENTIFIER_ID : '';
+  const tid = typeof TASK_ID !== 'undefined' ? TASK_ID : '';
+  return `pending_comment_${iid}_${tid}`;
 }
 
 /** _pendingComment를 갱신하고 localStorage에도 백업한다. */
@@ -814,8 +816,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   } catch { /* 무시 */ }
 
   try {
-    // IDENTIFIER_ID는 Jinja2 템플릿이 <script>로 주입하는 전역 변수다.
-    _item = await apiFetch(`/execution/api/item/${encodeURIComponent(IDENTIFIER_ID)}`);
+    // IDENTIFIER_ID, TASK_ID는 Jinja2 템플릿이 <script>로 주입하는 전역 변수다.
+    const taskParam = typeof TASK_ID !== 'undefined' && TASK_ID
+      ? `?task_id=${encodeURIComponent(TASK_ID)}` : '';
+    _item = await apiFetch(`/execution/api/item/${encodeURIComponent(IDENTIFIER_ID)}${taskParam}`);
     if (!_isStarted(_item.execution)) {
       // pending 상태: 이전에 미리 입력해 둔 코멘트를 localStorage에서 복원한다.
       _pendingComment = _item.execution?.comment || _loadPendingComment();

--- a/app/templates/execution/detail.html
+++ b/app/templates/execution/detail.html
@@ -25,6 +25,7 @@
 {% block scripts %}
 <script>
   var IDENTIFIER_ID = {{ identifier_id | tojson }};
+  var TASK_ID = {{ task_id | tojson }};
   var BARCODE_PREFIX = {{ barcode_prefix | tojson }};
 </script>
 <script src="{{ url_for('static', filename='execution/js/execution-detail.js') }}?v={{ cache_bust }}"></script>


### PR DESCRIPTION
## Summary

- `save_pre_comment`에서 `get_by_identifier`(identifier_id만 조회) → `get_by_identifier_and_task`(identifier_id + task_id 조합)로 변경하여 재시험의 pre-comment가 원본 시험 레코드에 영향을 주지 않도록 수정
- 상세 페이지에 `task_id` 쿼리 파라미터를 전달하고 `TASK_ID` JS 변수로 주입, API 호출 시 포함
- localStorage pending comment 키를 `pending_comment_{iid}_{tid}` 형태로 변경하여 원본/재시험 간 분리
- 목록 → 상세 이동 URL에 `task_id` 포함하여 동일 identifier를 가진 원본/재시험이 각자의 실행 레코드를 독립적으로 표시

## Test plan

- [ ] 동일 `identifier_id`를 가진 원본(exam_no=1)과 재시험(exam_no=2) 태스크 생성
- [ ] 원본 시험에서 pre-comment 저장 → 재시험 상세 페이지에서 코멘트가 보이지 않는지 확인
- [ ] 목록에서 재시험 행 클릭 시 URL에 `task_id`가 포함되어 올바른 실행 레코드가 표시되는지 확인
- [ ] 원본/재시험 각각 독립적으로 시험 시작·완료 가능한지 확인

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)