### PR TITLE
[codex] Fix execution list display issues

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -65,9 +65,33 @@ def _notify_timing(identifier_id: str, task_id: str, elapsed_seconds: int):
     threading.Thread(target=_send, daemon=True).start()
 
 
-def _get_total_count(identifier_id: str) -> int:
-    # TODO: 실제 외부 API 연동 — 현재는 모든 식별자에 10을 고정 반환
-    return 10
+def _identifier_total_count(identifier: dict) -> int:
+    """식별자 데이터에 저장된 전체 시험 건수를 반환한다.
+
+    외부 API 연동 전까지 10을 고정 반환하던 값이 결과를 오염시키지 않도록,
+    동기화 데이터에 명시된 카운트 필드를 우선 사용하고 없으면 0으로 둔다.
+    """
+    for key in ('total_count', 'test_count', 'case_count', 'count'):
+        value = identifier.get(key)
+        if value in (None, ''):
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def _get_total_count(identifier_id: str, task_id: str = '') -> int:
+    from app.features.schedule.models import task as task_repo
+
+    for task in task_repo.get_all():
+        if task_id and task.get('id') != task_id:
+            continue
+        for identifier in task.get('identifiers', []):
+            if isinstance(identifier, dict) and identifier.get('id') == identifier_id:
+                return _identifier_total_count(identifier)
+    return 0
 
 
 def _execution_response(ex):
@@ -92,6 +116,7 @@ def _execution_response(ex):
         'pass_count': ex.get('pass_count', 0),
         'comment': ex.get('comment', ''),
         'performer': ex.get('performer', ''),
+        'completed_at': ex.get('completed_at'),
     }
 
 
@@ -101,9 +126,9 @@ def _load_schedule_data():
     Returns:
         tasks (list): 전체 태스크 목록
         locations (dict): location_id → location 객체
-        date_map (dict): identifier_id → 가장 이른 배치 날짜(YYYY-MM-DD)
+        date_map (dict): (task_id, identifier_id) → 가장 이른 배치 날짜(YYYY-MM-DD)
             식별자가 여러 블록에 걸쳐 배치됐을 때 가장 빠른 날짜를 사용한다.
-        block_loc_map (dict): identifier_id → 블록에 지정된 location_id
+        block_loc_map (dict): (task_id, identifier_id) → 블록에 지정된 location_id
             블록에 장소가 명시되지 않은 식별자는 포함되지 않으며,
             이 경우 태스크의 location_id로 폴백한다.
             (버그 #104 수정: 이전에는 항상 태스크 장소를 사용했다.)
@@ -120,8 +145,8 @@ def _load_schedule_data():
     blocks = block_repo.get_all()
     locations = {loc['id']: loc for loc in loc_repo.get_all()}
 
-    date_map = {}        # identifier_id → earliest scheduled date
-    block_loc_map = {}   # identifier_id → location_id from block
+    date_map = {}        # (task_id, identifier_id) → earliest scheduled date
+    block_loc_map = {}   # (task_id, identifier_id) → location_id from block
 
     for block in blocks:
         block_date = block.get('date', '')
@@ -136,11 +161,12 @@ def _load_schedule_data():
             iid = identifier['id'] if isinstance(identifier, dict) else identifier
             # block_iids가 None(전체 포함 블록)이거나 해당 식별자가 블록에 속할 때만 처리
             if block_iids is None or iid in block_iids:
+                key = (block_task_id, iid)
                 # 더 이른 날짜의 블록이 발견되면 날짜와 장소를 함께 갱신
-                if iid not in date_map or block_date < date_map[iid]:
-                    date_map[iid] = block_date
+                if key not in date_map or block_date < date_map[key]:
+                    date_map[key] = block_date
                     if block_loc:
-                        block_loc_map[iid] = block_loc
+                        block_loc_map[key] = block_loc
 
     return tasks, locations, date_map, block_loc_map
 
@@ -163,6 +189,7 @@ def _build_item_dict(task, identifier, locations, scheduled_date, block_loc_id='
     loc_id = block_loc_id or task.get('location_id', '')
     loc_name = locations.get(loc_id, {}).get('name', '') if loc_id else ''
     execution = ExecutionRepository.get_by_identifier_and_task(iid, task['id'])
+    completed_at = execution.get('completed_at') if execution else None
     exam_no = task.get('exam_no')
     doc_name = task.get('doc_name', '')
     display_name = f'{doc_name} ({exam_no}차)' if exam_no is not None and exam_no != 1 else doc_name
@@ -178,6 +205,8 @@ def _build_item_dict(task, identifier, locations, scheduled_date, block_loc_id='
         'location_id': loc_id,
         'location_name': loc_name,
         'scheduled_date': scheduled_date,
+        'display_date': completed_at or scheduled_date,
+        'total_count': _identifier_total_count(identifier),
         # 실행 레코드가 없으면 None (미시작 상태를 프론트에서 pending으로 표시)
         'execution': _execution_response(execution),
     }
@@ -203,8 +232,9 @@ def execution_list():
             if not isinstance(identifier, dict):
                 continue
             iid = identifier['id']
-            scheduled_date = date_map.get(iid, '')
-            block_loc_id = block_loc_map.get(iid, '')
+            key = (task['id'], iid)
+            scheduled_date = date_map.get(key, '')
+            block_loc_id = block_loc_map.get(key, '')
             # 필터 적용 시 블록 장소 우선, 없으면 태스크 장소로 폴백
             loc_id = block_loc_id or task.get('location_id', '')
             if date_filter and scheduled_date != date_filter:
@@ -231,16 +261,16 @@ def get_item(identifier_id):
                 continue
             return jsonify(_build_item_dict(
                 task, identifier, locations,
-                date_map.get(identifier_id, ''),
-                block_loc_map.get(identifier_id, ''),
+                date_map.get((task['id'], identifier_id), ''),
+                block_loc_map.get((task['id'], identifier_id), ''),
             ))
     return jsonify({'error': 'not found'}), 404
 
 
 @api_bp.route('/total-count/<identifier_id>')
 def total_count(identifier_id):
-    """식별자의 전체 시험 케이스 수를 반환한다. (현재 외부 API 미연동, 고정값 반환)"""
-    return jsonify({'total_count': _get_total_count(identifier_id)})
+    """식별자의 전체 시험 케이스 수를 반환한다."""
+    return jsonify({'total_count': _get_total_count(identifier_id, request.args.get('task_id', ''))})
 
 
 @api_bp.route('/whoami')
@@ -296,7 +326,7 @@ def start():
             if performer:
                 return jsonify({'error': f'"{performer}"님이 시험을 진행 중입니다.', 'code': 'another_user_busy'}), 409
 
-    total = _get_total_count(identifier_id)
+    total = _get_total_count(identifier_id, task_id)
     ex = ExecutionRepository.start(identifier_id, task_id, total_count=total)
 
     # start() 후 performer가 비어 있을 때만 세션 사용자를 지정

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -279,7 +279,7 @@ function setSort(col) {
  *   - 날짜·장소 필터는 loadList() 단계에서 서버에 파라미터로 전달하므로 여기서는 처리 안 함
  *
  * 정렬:
- *   - 'date': scheduled_date 문자열 비교 (ISO 형식이므로 사전순 = 날짜순)
+ *   - 'date': display_date 문자열 비교 (완료 시각 우선, 없으면 배치 날짜)
  *   - 'location': location_name 문자열 비교
  *   - 'status': STATUS_ORDER 숫자 비교
  */
@@ -293,7 +293,7 @@ function applyAndRender() {
   if (_sortCol) {
     items.sort((a, b) => {
       let va, vb;
-      if (_sortCol === 'date')     { va = a.scheduled_date || ''; vb = b.scheduled_date || ''; }
+      if (_sortCol === 'date')     { va = a.display_date || a.scheduled_date || ''; vb = b.display_date || b.scheduled_date || ''; }
       else if (_sortCol === 'location') { va = a.location_name || ''; vb = b.location_name || ''; }
       else if (_sortCol === 'status')   {
         // 상태는 문자열이 아닌 미리 정의된 숫자 순서로 비교한다.
@@ -391,7 +391,7 @@ function buildRow(item) {
   if (colVisible('name'))       cells.push(`<td class="td-name">${escHtml(item.identifier_name)}${renderCommentIcon(item)}</td>`);
   if (colVisible('assignee'))   cells.push(`<td class="td-meta">${escHtml(assignee)}</td>`);
   if (colVisible('location'))   cells.push(`<td class="td-meta">${escHtml(item.location_name || '-')}</td>`);
-  if (colVisible('date'))       cells.push(`<td class="td-meta">${escHtml(item.scheduled_date || '-')}</td>`);
+  if (colVisible('date'))       cells.push(`<td class="td-meta">${escHtml(item.display_date || item.scheduled_date || '-')}</td>`);
   if (colVisible('estimated'))  cells.push(`<td class="td-meta">${formatMinutes(item.estimated_minutes)}</td>`);
   if (colVisible('performer'))  cells.push(`<td>${escHtml(item.execution?.performer || '-')}</td>`);
   if (colVisible('result'))     cells.push(renderResultCell(item));

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -337,8 +337,8 @@ function renderPage() {
     const dis    = !started ? 'disabled' : '';
     const failV  = started ? ex.fail_count      : 0;
     const blockV = started ? (ex.block_count ?? 0) : 0;
-    const passV  = started ? ex.pass_count      : 0;
     const total  = started ? ex.total_count     : 0;
+    const passV  = started ? Math.max(0, total - failV - blockV) : 0;
     const maxA   = started ? `max="${total}"`   : '';
     failPassHtml = `
     <div class="exec-counts-bar mb-3">
@@ -628,6 +628,7 @@ async function doStart() {
       id: ex.id, status: ex.status, elapsed_seconds: 0,
       total_count: ex.total_count, fail_count: 0, block_count: 0, pass_count: 0,
       comment: _pendingComment, performer: ex.performer || _pendingPerformer,
+      completed_at: ex.completed_at || null,
     };
     // 시작 전에 입력된 코멘트·수행자를 이제 실제 execution에 반영한다.
     if (_pendingComment)   await apiFetch('/execution/api/comment', 'PUT', { execution_id: ex.id, comment: _pendingComment });
@@ -693,8 +694,9 @@ async function doComplete() {
       ..._item.execution, status: 'completed',
       fail_count: ex.fail_count, block_count: ex.block_count ?? blockCount,
       pass_count: ex.pass_count, elapsed_seconds: _computeElapsed(ex),
-      comment,
+      total_count: ex.total_count, comment, completed_at: ex.completed_at || null,
     };
+    _item.display_date = _item.execution.completed_at || _item.scheduled_date || '';
     renderPage();
   } catch { alert('완료 처리 실패'); }
 }

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -216,6 +216,101 @@ class TestExecutionAPI:
         assert r.status_code == 200
         assert 'total_count' in r.get_json()
 
+    def test_total_count_uses_identifier_data_not_hardcoded_ten(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.schedule.models import task as task_repo
+
+            task_repo.create(
+                doc_id=1,
+                assignee_names=[],
+                location_id='',
+                doc_name='카운트 문서',
+                identifiers=[
+                    {'id': 'TC-COUNT', 'name': '카운트 시험', 'estimated_minutes': 10, 'total_count': 7},
+                ],
+                estimated_minutes=10,
+            )
+
+        r = exec_client.get('/execution/api/total-count/TC-COUNT')
+        assert r.status_code == 200
+        assert r.get_json()['total_count'] == 7
+
+    def test_complete_result_counts_and_completed_date_are_listed(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.schedule.models import task as task_repo
+            from app.features.execution.models.execution import ExecutionRepository
+
+            t = task_repo.create(
+                doc_id=2,
+                assignee_names=[],
+                location_id='',
+                doc_name='결과 문서',
+                identifiers=[
+                    {'id': 'TC-RESULT', 'name': '결과 시험', 'estimated_minutes': 10, 'total_count': 9},
+                ],
+                estimated_minutes=10,
+            )
+            ex = ExecutionRepository.start('TC-RESULT', t['id'], total_count=9)
+            done = ExecutionRepository.complete(ex['id'], fail_count=2, block_count=3)
+
+        r = exec_client.get('/execution/api/list')
+        item = next(i for i in r.get_json() if i['identifier_id'] == 'TC-RESULT')
+        assert item['execution']['fail_count'] == 2
+        assert item['execution']['block_count'] == 3
+        assert item['execution']['pass_count'] == 4
+        assert item['execution']['total_count'] == 9
+        assert item['execution']['completed_at'] == done['completed_at']
+        assert item['display_date'] == done['completed_at']
+
+    def test_list_uses_scheduled_block_location_per_task_identifier(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.schedule.models import location as loc_repo
+            from app.features.schedule.models import schedule_block as block_repo
+            from app.features.schedule.models import task as task_repo
+
+            loc_a = loc_repo.create('시험실A', '#111111')
+            loc_b = loc_repo.create('시험실B', '#222222')
+            task1 = task_repo.create(
+                doc_id=3,
+                assignee_names=[],
+                location_id=loc_a['id'],
+                doc_name='원본',
+                identifiers=[{'id': 'TC-SAME', 'name': '원본 시험', 'estimated_minutes': 10}],
+                estimated_minutes=10,
+            )
+            task2 = task_repo.create(
+                doc_id=4,
+                assignee_names=[],
+                location_id=loc_a['id'],
+                doc_name='재시험',
+                identifiers=[{'id': 'TC-SAME', 'name': '재시험', 'estimated_minutes': 10}],
+                estimated_minutes=10,
+                exam_no=2,
+            )
+            block_repo.create(
+                task_id=task1['id'],
+                assignee_names=[],
+                location_id=loc_a['id'],
+                date='2026-07-01',
+                start_time='09:00',
+                end_time='10:00',
+                identifier_ids=['TC-SAME'],
+            )
+            block_repo.create(
+                task_id=task2['id'],
+                assignee_names=[],
+                location_id=loc_b['id'],
+                date='2026-07-01',
+                start_time='10:00',
+                end_time='11:00',
+                identifier_ids=['TC-SAME'],
+            )
+
+        r = exec_client.get('/execution/api/list')
+        items = {i['task_id']: i for i in r.get_json() if i['identifier_id'] == 'TC-SAME'}
+        assert items[task1['id']]['location_name'] == '시험실A'
+        assert items[task2['id']]['location_name'] == '시험실B'
+
     def test_execution_page(self, exec_client):
         r = exec_client.get('/execution/')
         assert r.status_code == 200


### PR DESCRIPTION
## What changed

- Show the scheduled block location on execution list/detail responses using `(task_id, identifier_id)` scoped schedule maps.
- Remove the hardcoded execution `total_count = 10` fallback and derive it from identifier data when present.
- Include `completed_at` in execution API responses and expose `display_date` so completed rows show completion time in the date column.
- Keep result count rendering consistent after start/complete flows.
- Add regression tests for location display, result counts, and completed date display.

## Why

Issues #125, #126, and #127 reported missing execution dates, hardcoded result counts, and missing scheduled locations. The root causes were incomplete execution response fields, a hardcoded total count helper, and schedule lookup maps keyed only by identifier ID.

## Validation

- `pytest tests/test_execution.py tests/test_execution_model.py` passed: 23 passed.
- `git diff --check` passed.
- Full `pytest` result: 196 passed, 1 failed due to the local environment missing `openpyxl`; `requirements.txt` already lists `openpyxl`, and the failure is in xlsx export fallback behavior outside this change.
