### PR TITLE
[codex] Fix JSON file encoding handling

### DIFF
--- a/app/features/execution/store.py
+++ b/app/features/execution/store.py
@@ -57,7 +57,7 @@ def read_json(filename):
     path = _get_path(filename)
     if not os.path.exists(path):
         return []
-    with portalocker.Lock(path, 'r', timeout=5) as f:
+    with portalocker.Lock(path, 'r', timeout=5, encoding='utf-8') as f:
         content = f.read()
         if not content.strip():
             return []
@@ -78,6 +78,6 @@ def write_json(filename, data):
     # 데이터 유실 방지를 위해 기존 파일을 .bak으로 백업
     if os.path.exists(path):
         shutil.copy2(path, path + '.bak')
-    with portalocker.Lock(path, 'w', timeout=5) as f:
+    with portalocker.Lock(path, 'w', timeout=5, encoding='utf-8') as f:
         # ensure_ascii=False: 한글 등 유니코드를 그대로 저장
         json.dump(data, f, ensure_ascii=False, indent=2)

--- a/app/features/schedule/providers/dyn_ready.py
+++ b/app/features/schedule/providers/dyn_ready.py
@@ -24,13 +24,13 @@ def _meta_path():
 def _load_meta():
     path = _meta_path()
     if os.path.exists(path):
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             return json.load(f)
     return {}
 
 
 def _save_meta(meta):
-    with open(_meta_path(), 'w') as f:
+    with open(_meta_path(), 'w', encoding='utf-8') as f:
         json.dump(meta, f)
 
 

--- a/app/features/schedule/store.py
+++ b/app/features/schedule/store.py
@@ -59,7 +59,7 @@ def read_json(filename):
     if not os.path.exists(path):
         # settings.json은 단일 객체, 나머지는 배열 형태
         return [] if filename != 'settings.json' else {}
-    with portalocker.Lock(path, 'r', timeout=5) as f:
+    with portalocker.Lock(path, 'r', timeout=5, encoding='utf-8') as f:
         content = f.read()
         if not content.strip():
             # 파일이 비어 있는 경우에도 기본값 반환
@@ -81,6 +81,6 @@ def write_json(filename, data):
     # 데이터 유실 방지를 위해 기존 파일을 .bak으로 백업
     if os.path.exists(path):
         shutil.copy2(path, path + '.bak')
-    with portalocker.Lock(path, 'w', timeout=5) as f:
+    with portalocker.Lock(path, 'w', timeout=5, encoding='utf-8') as f:
         # ensure_ascii=False: 한글 등 유니코드를 그대로 저장
         json.dump(data, f, ensure_ascii=False, indent=2)

--- a/tests/test_store_encoding.py
+++ b/tests/test_store_encoding.py
@@ -1,0 +1,84 @@
+import json
+import os
+import builtins
+
+from app import create_app
+
+
+def _make_app(tmp_path):
+    data_dir = str(tmp_path / 'data')
+    exec_dir = str(tmp_path / 'exec_data')
+    os.makedirs(data_dir)
+    os.makedirs(exec_dir)
+    app = create_app()
+    app.config['DATA_DIR'] = data_dir
+    app.config['EXECUTION_DATA_DIR'] = exec_dir
+    app.config['TESTING'] = True
+    return app
+
+
+def _tracking_lock(calls):
+    class TrackingLock:
+        def __init__(self, path, mode='r', **kwargs):
+            calls.append({'path': path, 'mode': mode, 'kwargs': kwargs})
+            self.path = path
+            self.mode = mode
+            self.kwargs = kwargs
+            self.file = None
+
+        def __enter__(self):
+            self.file = builtins.open(
+                self.path,
+                self.mode,
+                encoding=self.kwargs.get('encoding'),
+            )
+            return self.file
+
+        def __exit__(self, exc_type, exc, tb):
+            self.file.close()
+
+    return TrackingLock
+
+
+def test_schedule_store_reads_and_writes_utf8(tmp_path, monkeypatch):
+    app = _make_app(tmp_path)
+    calls = []
+
+    with app.app_context():
+        from app.features.schedule import store
+
+        monkeypatch.setattr(store.portalocker, 'Lock', _tracking_lock(calls))
+
+        store.write_json('users.json', [{'name': '시험 담당자 — 홍길동'}])
+        assert store.read_json('users.json') == [{'name': '시험 담당자 — 홍길동'}]
+
+    assert [call['kwargs'].get('encoding') for call in calls] == ['utf-8', 'utf-8']
+
+
+def test_execution_store_reads_and_writes_utf8(tmp_path, monkeypatch):
+    app = _make_app(tmp_path)
+    calls = []
+
+    with app.app_context():
+        from app.features.execution import store
+
+        monkeypatch.setattr(store.portalocker, 'Lock', _tracking_lock(calls))
+
+        store.write_json('executions.json', [{'comment': '완료 — 정상'}])
+        assert store.read_json('executions.json') == [{'comment': '완료 — 정상'}]
+
+    assert [call['kwargs'].get('encoding') for call in calls] == ['utf-8', 'utf-8']
+
+
+def test_dyn_ready_meta_uses_utf8(tmp_path):
+    app = _make_app(tmp_path)
+
+    with app.app_context():
+        from app.features.schedule.providers import dyn_ready
+
+        meta = {'updated_at': '2026-07-06T00:00:00', 'label': '메타 — 정상'}
+        dyn_ready._save_meta(meta)
+        assert dyn_ready._load_meta() == meta
+
+        with open(os.path.join(app.config['DATA_DIR'], 'dyn_ready_meta.json'), encoding='utf-8') as f:
+            assert json.load(f) == meta


### PR DESCRIPTION
## What changed

- Explicitly read and write schedule JSON store files as UTF-8.
- Explicitly read and write execution JSON store files as UTF-8.
- Explicitly read and write dyn_ready metadata as UTF-8.
- Added regression tests that verify the store layer passes UTF-8 encoding through file locks and can round-trip Korean/Unicode content.

## Why

Fixes #129. On Windows, Python can default text file reads to cp949. Existing JSON data is written with `ensure_ascii=False`, so UTF-8 bytes could fail with `UnicodeDecodeError` when read without an explicit encoding.

## Validation

- `pytest tests/test_store_encoding.py tests/test_std_list.py tests/test_execution.py tests/test_execution_model.py` passed: 29 passed.
- `git diff --check` passed.
- Full `pytest`: 199 passed, 1 failed because local environment is missing `openpyxl`; `requirements.txt` already lists `openpyxl`, and the failing xlsx export fallback is unrelated to this change.
