### PR TITLE
[codex] Fix execution user busy guard

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -300,7 +300,7 @@ def start():
 
     중복 진행 방지 로직:
         세션 사용자가 현재 다른 식별자를 진행 중이면 409를 반환한다.
-        수행자가 지정된 다른 실행이 있어도 409를 반환한다.
+        다른 수행자가 진행 중인 실행은 현재 사용자의 시작을 막지 않는다.
         단, 동일 식별자에 대한 재시작은 항상 허용한다.
 
     시작 후 performer가 비어 있으면 현재 세션 사용자를 자동으로 지정한다.
@@ -323,8 +323,6 @@ def start():
             performer = ex.get('performer', '')
             if performer == current_user:
                 return jsonify({'error': '이미 진행 중인 시험이 있습니다.', 'code': 'user_busy'}), 409
-            if performer:
-                return jsonify({'error': f'"{performer}"님이 시험을 진행 중입니다.', 'code': 'another_user_busy'}), 409
 
     total = _get_total_count(identifier_id, task_id)
     ex = ExecutionRepository.start(identifier_id, task_id, total_count=total)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -162,6 +162,34 @@ class TestExecutionAPI:
         data = r.get_json()
         assert data['status'] == 'in_progress'
 
+    def test_start_allows_when_other_performer_is_in_progress(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.execution.models.execution import ExecutionRepository
+
+            ex = ExecutionRepository.start('TC-OTHER', 't_other', total_count=0)
+            ExecutionRepository.update_performer(ex['id'], 'alice')
+
+        exec_client.post('/execution/api/login', json={'username': 'bob'})
+        r = exec_client.post('/execution/api/start', json={
+            'identifier_id': 'TC-BOB', 'task_id': 't_bob'
+        })
+        assert r.status_code == 201
+        assert r.get_json()['performer'] == 'bob'
+
+    def test_start_blocks_when_current_user_is_already_in_progress(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.execution.models.execution import ExecutionRepository
+
+            ex = ExecutionRepository.start('TC-ALICE', 't_alice', total_count=0)
+            ExecutionRepository.update_performer(ex['id'], 'alice')
+
+        exec_client.post('/execution/api/login', json={'username': 'alice'})
+        r = exec_client.post('/execution/api/start', json={
+            'identifier_id': 'TC-NEW', 'task_id': 't_new'
+        })
+        assert r.status_code == 409
+        assert r.get_json()['code'] == 'user_busy'
+
     def test_pause(self, exec_client):
         r = exec_client.post('/execution/api/start', json={
             'identifier_id': 'TC-001', 'task_id': 't_001'


### PR DESCRIPTION
## What changed

- Narrowed the execution start busy check to the logged-in user only.
- Other performers with in-progress executions no longer block the current user from starting their own test.
- Added regression coverage for both allowed different-user starts and blocked same-user duplicate starts.

## Why

Fixes #131. The previous guard treated any in-progress execution with a performer as a global blocker, which could prevent a logged-in user from entering execution even when they were not testing another item.

## Validation

- `pytest tests/test_execution.py tests/test_execution_model.py` passed: 25 passed.
- `git diff --check` passed.
- Full `pytest`: 198 passed, 1 failed because local environment is missing `openpyxl`; `requirements.txt` already lists `openpyxl`, and the xlsx export fallback failure is unrelated to this change.
