### PR TITLE
[codex] Fix sync handling for deleted tasks

### DIFF
--- a/app/features/schedule/services/sync.py
+++ b/app/features/schedule/services/sync.py
@@ -6,7 +6,7 @@ exam_no 기반 태스크 분리: std_list_cache.json의 데이터를 참조하�
 (doc_id, exam_no) 조합별로 독립 태스크를 생성한다.
 """
 
-from app.features.schedule.models import version, task
+from app.features.schedule.models import version, task, schedule_block
 from app.features.schedule.providers.base import NoChangesError
 from app.config import OfpidSettings
 
@@ -15,6 +15,55 @@ def load_std_list_cache():
     """std_list 로컬 캐시를 읽어 반환한다. 없으면 []."""
     from app.features.schedule.models.std_list import load_cache
     return load_cache()
+
+
+def _task_blocks(task_id):
+    """task_id에 연결된 스케줄 블록 목록을 반환한다."""
+    return [b for b in schedule_block.get_all() if b.get('task_id') == task_id]
+
+
+def _scheduled_identifier_ids(task_dict):
+    """해당 task에서 이미 스케줄 블록에 배치된 식별자 ID 집합을 반환한다.
+
+    identifier_ids=None인 블록은 task 전체가 배치된 것으로 간주한다.
+    """
+    identifiers = [
+        i.get('id') for i in task_dict.get('identifiers', [])
+        if isinstance(i, dict) and i.get('id')
+    ]
+    scheduled = set()
+    for block in _task_blocks(task_dict['id']):
+        block_ids = block.get('identifier_ids')
+        if block_ids is None:
+            scheduled.update(identifiers)
+        else:
+            scheduled.update(block_ids)
+    return scheduled
+
+
+def _merge_preserving_scheduled_removed(existing, incoming, warnings):
+    """동기화에서 삭제된 식별자 중 이미 배치된 항목은 보존한다."""
+    incoming_ids = {
+        i.get('id') for i in incoming
+        if isinstance(i, dict) and i.get('id')
+    }
+    scheduled_ids = _scheduled_identifier_ids(existing)
+    merged = list(incoming)
+
+    for old in existing.get('identifiers', []):
+        if not isinstance(old, dict):
+            continue
+        old_id = old.get('id')
+        if not old_id or old_id in incoming_ids:
+            continue
+        if old_id in scheduled_ids:
+            merged.append(old)
+            warnings.append(
+                f"{existing.get('doc_name', '')} / {old_id}: "
+                "이미 스케줄 블록에 배치되어 동기화 삭제를 건너뜀"
+            )
+
+    return merged
 
 
 class SyncService:
@@ -60,7 +109,8 @@ class SyncService:
             version_id: 특정 버전 ID로 제한. None이면 전체.
 
         Returns:
-            dict: {'added': int, 'updated': int, 'cancelled': int, 'warnings': list}
+            dict: {'added': int, 'updated': int, 'deleted': int,
+                   'cancelled': int, 'warnings': list}
         """
         try:
             if version_id:
@@ -80,7 +130,7 @@ class SyncService:
                 exam_no_map.setdefault(ti, set()).add(en)
 
         synced_combos = set()  # {(doc_id, exam_no)} 이번 sync에서 처리한 조합
-        added = updated = cancelled = 0
+        added = updated = deleted = 0
         warnings = []
 
         for item in external:
@@ -128,6 +178,14 @@ class SyncService:
 
                 existing = task.get_by_doc_and_exam(doc_id, exam_no)
                 if existing:
+                    idents = _merge_preserving_scheduled_removed(
+                        existing, idents, warnings,
+                    )
+                    est_minutes = sum(
+                        i.get('estimated_minutes', 0)
+                        for i in idents
+                        if isinstance(i, dict)
+                    )
                     task.patch(existing['id'],
                                identifiers=idents,
                                estimated_minutes=est_minutes,
@@ -147,15 +205,23 @@ class SyncService:
                     )
                     added += 1
 
-        # 이번 sync 결과에 없는 (doc_id, exam_no) 조합을 취소 처리
+        # 이번 sync 결과에 없는 (doc_id, exam_no) 조합은 삭제한다.
+        # 단, 이미 스케줄 블록에 배치된 task는 삭제하지 않고 경고만 반환한다.
         for t in task.get_all():
             did = t.get('doc_id')
             if did is None:
                 continue
             combo = (did, t.get('exam_no'))
-            if combo not in synced_combos and t.get('status') != 'cancelled':
-                task.patch(t['id'], status='cancelled')
-                cancelled += 1
+            if combo not in synced_combos:
+                if _task_blocks(t['id']):
+                    warnings.append(
+                        f"{t.get('doc_name', '')}: 이미 스케줄 블록에 배치되어 "
+                        "동기화 삭제를 건너뜀"
+                    )
+                    continue
+                task.delete(t['id'])
+                deleted += 1
 
         return {'added': added, 'updated': updated,
-                'cancelled': cancelled, 'warnings': warnings}
+                'deleted': deleted, 'cancelled': deleted,
+                'warnings': warnings}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from app import create_app
-from app.features.schedule.models import version, task
+from app.features.schedule.models import version, task, schedule_block
 from app.features.schedule.providers.base import BaseProvider
 from app.features.schedule.services.sync import SyncService
 
@@ -212,7 +212,7 @@ class TestSyncTestData:
             assert t['assignee_names'] == ['홍길동']
             assert t['location_id'] == 'loc_xyz'
 
-    def test_sync_cancels_removed_task(self):
+    def test_sync_deletes_removed_unscheduled_task(self):
         class MockProvider(BaseProvider):
             def get_versions(self):
                 return []
@@ -233,10 +233,124 @@ class TestSyncTestData:
             )
 
             result = SyncService.sync_test_data(MockProvider())
-            assert result['cancelled'] == 1
+            assert result['deleted'] == 1
 
+            assert task.get_by_doc_id(1) is None
+
+    def test_sync_keeps_removed_task_when_scheduled_and_warns(self):
+        class MockProvider(BaseProvider):
+            def get_versions(self):
+                return []
+            def get_test_data(self, version_id):
+                return []
+            def get_test_data_all(self):
+                return []
+
+        with self.app.app_context():
+            t = task.create(
+                doc_id=1,
+                version_id='VER-001',
+                assignee_names=[],
+                location_id='',
+                doc_name='시스템',
+                identifiers=[{'id': 'TC-001', 'estimated_minutes': 60, 'owners': []}],
+                estimated_minutes=60,
+            )
+            schedule_block.create(
+                task_id=t['id'],
+                assignee_names=[],
+                location_id='',
+                date='2026-07-07',
+                start_time='09:00',
+                end_time='10:00',
+            )
+
+            result = SyncService.sync_test_data(MockProvider())
+            assert result['deleted'] == 0
+            assert task.get_by_doc_id(1) is not None
+            assert any('이미 스케줄 블록에 배치' in w for w in result['warnings'])
+
+    def test_sync_removes_deleted_queue_identifier(self):
+        class MockProvider(BaseProvider):
+            def get_versions(self):
+                return []
+            def get_test_data(self, version_id):
+                return []
+            def get_test_data_all(self):
+                return [{
+                    'doc_id': 1,
+                    'doc_name': '시스템',
+                    'version_id': 'VER-001',
+                    'identifiers': [
+                        {'id': 'TC-001', 'estimated_minutes': 60, 'owners': []},
+                    ],
+                }]
+
+        with self.app.app_context():
+            task.create(
+                doc_id=1,
+                version_id='VER-001',
+                assignee_names=[],
+                location_id='',
+                doc_name='시스템',
+                identifiers=[
+                    {'id': 'TC-001', 'estimated_minutes': 60, 'owners': []},
+                    {'id': 'TC-002', 'estimated_minutes': 30, 'owners': []},
+                ],
+                estimated_minutes=90,
+            )
+
+            result = SyncService.sync_test_data(MockProvider())
+            assert result['warnings'] == []
             t = task.get_by_doc_id(1)
-            assert t['status'] == 'cancelled'
+            assert [i['id'] for i in t['identifiers']] == ['TC-001']
+            assert t['estimated_minutes'] == 60
+
+    def test_sync_keeps_deleted_scheduled_identifier_and_warns(self):
+        class MockProvider(BaseProvider):
+            def get_versions(self):
+                return []
+            def get_test_data(self, version_id):
+                return []
+            def get_test_data_all(self):
+                return [{
+                    'doc_id': 1,
+                    'doc_name': '시스템',
+                    'version_id': 'VER-001',
+                    'identifiers': [
+                        {'id': 'TC-001', 'estimated_minutes': 60, 'owners': []},
+                    ],
+                }]
+
+        with self.app.app_context():
+            t = task.create(
+                doc_id=1,
+                version_id='VER-001',
+                assignee_names=[],
+                location_id='',
+                doc_name='시스템',
+                identifiers=[
+                    {'id': 'TC-001', 'estimated_minutes': 60, 'owners': []},
+                    {'id': 'TC-002', 'estimated_minutes': 30, 'owners': []},
+                ],
+                estimated_minutes=90,
+            )
+            schedule_block.create(
+                task_id=t['id'],
+                assignee_names=[],
+                location_id='',
+                date='2026-07-07',
+                start_time='09:00',
+                end_time='10:00',
+                identifier_ids=['TC-002'],
+            )
+
+            result = SyncService.sync_test_data(MockProvider())
+            t = task.get_by_doc_id(1)
+            assert [i['id'] for i in t['identifiers']] == ['TC-001', 'TC-002']
+            assert t['estimated_minutes'] == 90
+            assert any('TC-002' in w and '이미 스케줄 블록에 배치' in w
+                       for w in result['warnings'])
 
     def test_sync_creates_exam_no_tasks_from_cache(self):
         """std_list 캐시가 있으면 (doc_id, exam_no) 조합별로 태스크를 생성한다."""
@@ -341,12 +455,9 @@ class TestSyncTestData:
                 SyncService.sync_test_data(MockProvider())
 
             tasks = task.get_all()
-            # exam_no=None 태스크는 cancelled, exam_no=1 태스크가 새로 생성됨
-            cancelled = [t for t in tasks if t.get('status') == 'cancelled']
-            active = [t for t in tasks if t.get('status') != 'cancelled']
-            assert len(cancelled) == 1
-            assert len(active) == 1
-            assert active[0]['exam_no'] == 1
+            # exam_no=None 태스크는 삭제되고, exam_no=1 태스크가 새로 생성됨
+            assert len(tasks) == 1
+            assert tasks[0]['exam_no'] == 1
 
 
 # ===========================================================================


### PR DESCRIPTION
## What changed

- During test-data sync, removed unscheduled tasks are now deleted instead of being left as cancelled tasks.
- If a removed task is already placed in a schedule block, sync keeps it and returns a warning explaining it cannot be deleted because it is scheduled.
- When identifiers are removed from an existing task, unscheduled identifiers are removed from the task queue.
- Removed identifiers that are already included in a schedule block are preserved and reported in warnings.
- Added regression tests for removed queued tasks, scheduled tasks, queued identifiers, and scheduled identifiers.

## Why

Fixes #134. External sync data can remove test items. Queue-only items should disappear locally, but items already placed on the schedule must not be silently removed because existing schedule blocks would lose their target data.

## Validation

- `pytest tests/test_sync.py` passed: 18 passed.
- `pytest tests/test_sync.py tests/test_routes_tasks.py` passed: 37 passed.
- `git diff --check` passed.
- Full `pytest`: 199 passed, 1 failed due to the existing local environment missing `openpyxl`; the xlsx export fallback failure is unrelated to this change.
