### PR TITLE
Add practitioner export sheet

### DIFF
--- a/app/features/schedule/helpers/enrichment.py
+++ b/app/features/schedule/helpers/enrichment.py
@@ -11,21 +11,19 @@ from datetime import date
 from app.features.schedule.helpers.time_utils import (
     generate_time_slots,
     is_break_slot,
-    work_minutes_in_range,
 )
 from app.features.schedule.models import (
     location,
     schedule_block,
-    settings,
     task,
     user,
 )
 
 STATUS_COLORS = {
-    'pending': '#94a3b8',      # Slate 400
+    'pending': '#94a3b8',  # Slate 400
     'in_progress': '#0d6efd',  # Bootstrap Primary / Blue 600
-    'completed': '#198754',    # Bootstrap Success / Green 600
-    'cancelled': '#dc3545',    # Bootstrap Danger / Red 600
+    'completed': '#198754',  # Bootstrap Success / Green 600
+    'cancelled': '#dc3545',  # Bootstrap Danger / Red 600
 }
 
 
@@ -97,6 +95,7 @@ def enrich_blocks(blocks, users_map, tasks_map, locations_map, color_by):
 
     # execution 데이터 로드
     from app.features.execution.models.execution import ExecutionRepository
+
     all_executions = ExecutionRepository.get_all()
     exec_by_task_identifier = {
         (ex['identifier_id'], ex.get('task_id', '')): ex for ex in all_executions
@@ -132,16 +131,26 @@ def enrich_blocks(blocks, users_map, tasks_map, locations_map, color_by):
             block['doc_id'] = ''
         else:
             # 일반 블록: 문서명 우선, 없으면 문서 ID, 태스크 삭제 시 '(삭제됨)'
-            block['task_title'] = t.get('doc_name') or str(t.get('doc_id', '(삭제됨)')) if t else '(삭제됨)'
+            block['task_title'] = (
+                t.get('doc_name') or str(t.get('doc_id', '(삭제됨)'))
+                if t
+                else '(삭제됨)'
+            )
         exam_no = t.get('exam_no') if t else None
         block['exam_no'] = exam_no
         if is_simple:
             block['display_name'] = b.get('title', '(블록)')
         else:
             base = t.get('doc_name', '') if t else ''
-            block['display_name'] = f'{base} ({exam_no}차)' if exam_no is not None and exam_no != 1 else base
+            block['display_name'] = (
+                f'{base} ({exam_no}차)'
+                if exam_no is not None and exam_no != 1
+                else base
+            )
         block['assignee_names'] = assignee_name_list
-        block['assignee_name'] = ', '.join(assignee_name_list) if assignee_name_list else '(미배정)'
+        block['assignee_name'] = (
+            ', '.join(assignee_name_list) if assignee_name_list else '(미배정)'
+        )
         # 첫 번째 담당자의 색상을 대표 색상으로 사용
         block['assignee_color'] = assignee_colors[0] if assignee_colors else '#6c757d'
         block['location_name'] = loc['name'] if loc else ''
@@ -154,22 +163,26 @@ def enrich_blocks(blocks, users_map, tasks_map, locations_map, color_by):
             # 이 블록에 해당하는 식별자들 (없으면 전체)
             b_iids = b.get('identifier_ids')
             if b_iids is None:
-                b_iids = [idf['id'] if isinstance(idf, dict) else idf 
-                         for idf in t.get('identifiers', [])]
-            
+                b_iids = [
+                    idf['id'] if isinstance(idf, dict) else idf
+                    for idf in t.get('identifiers', [])
+                ]
+
             # 각 식별자의 execution 상태 수집
             statuses = []
             for iid in b_iids:
                 ex = exec_by_task_identifier.get((iid, t['id']))
                 statuses.append(ex.get('status', 'pending') if ex else 'pending')
-            
+
             if all(s == 'completed' for s in statuses):
                 derived_status = 'completed'
-            elif any(s in ('in_progress', 'paused') for s in statuses) or any(s == 'completed' for s in statuses):
+            elif any(s in ('in_progress', 'paused') for s in statuses) or any(
+                s == 'completed' for s in statuses
+            ):
                 derived_status = 'in_progress'
             else:
                 derived_status = 'pending'
-            
+
             # 수동 상태가 'cancelled'인 경우 보존
             if b.get('block_status') == 'cancelled':
                 block['block_status'] = 'cancelled'
@@ -180,13 +193,16 @@ def enrich_blocks(blocks, users_map, tasks_map, locations_map, color_by):
 
         # color_by 설정에 따라 블록 표시 색상 결정
         if color_by == 'status':
-            block['color'] = STATUS_COLORS.get(block['block_status'], STATUS_COLORS['pending'])
+            block['color'] = STATUS_COLORS.get(
+                block['block_status'], STATUS_COLORS['pending']
+            )
         elif color_by == 'location':
             block['color'] = block['location_color']
         else:
             block['color'] = block['assignee_color']
 
         block['memo'] = t.get('memo', '') if t else b.get('memo', '')
+        block['identifiers'] = t.get('identifiers', []) if t else []
         block['identifier_ids'] = b.get('identifier_ids')
         block['is_simple'] = b.get('is_simple', False)
         block['title'] = b.get('title', '')
@@ -198,17 +214,21 @@ def enrich_blocks(blocks, users_map, tasks_map, locations_map, color_by):
         block['total_identifier_count'] = total_ids
         block['block_identifier_count'] = len(block_ids) if block_ids else total_ids
         # 블록이 분할(split)되었는지 판단: identifier_ids가 명시적이고 전체보다 적을 때
-        block['is_split'] = block_ids is not None and total_ids > 0 and len(block_ids) < total_ids
+        block['is_split'] = (
+            block_ids is not None and total_ids > 0 and len(block_ids) < total_ids
+        )
 
         # 분할 상태 결정: 나머지 식별자가 다른 블록에 배치되었는지 확인
         if block['is_split'] and t:
             # 태스크의 전체 식별자 ID 집합
-            all_task_ids = set(item['id'] if isinstance(item, dict) else item
-                              for item in t.get('identifiers', []))
+            all_task_ids = set(
+                item['id'] if isinstance(item, dict) else item
+                for item in t.get('identifiers', [])
+            )
             # 이 태스크의 모든 블록에서 배치된 식별자 ID 수집
             placed_ids = set()
             for tb in all_blocks_by_task.get(b.get('task_id'), []):
-                for iid in (tb.get('identifier_ids') or all_task_ids):
+                for iid in tb.get('identifier_ids') or all_task_ids:
                     placed_ids.add(iid)
             unplaced = all_task_ids - placed_ids
             # 미배치 식별자가 있으면 'partial', 모두 배치되면 'split'
@@ -249,7 +269,6 @@ def get_queue_tasks(users_map, locations_map, version_id=None):
     """
     tasks = task.get_all()
     all_blocks = schedule_block.get_all()
-    sttngs = settings.get()
 
     # 태스크별 배치된 블록 목록 구성
     task_blocks = {}  # tid → list of blocks
@@ -260,6 +279,7 @@ def get_queue_tasks(users_map, locations_map, version_id=None):
         task_blocks.setdefault(tid, []).append(b)
 
     from app.features.execution.models.execution import ExecutionRepository
+
     all_executions = ExecutionRepository.get_all()
     # (identifier_id, task_id) 조합을 키로 사용해 재시험 레코드가 섞이지 않게 한다.
     exec_by_task_identifier = {
@@ -311,8 +331,10 @@ def get_queue_tasks(users_map, locations_map, version_id=None):
         # 일부 식별자만 블록에 배치된 경우(분할 블록),
         # 아직 배치되지 않은 식별자들의 예상 시간을 remaining으로 계산한다.
         # -------------------------------------------------------------------------
-        all_ids = [item['id'] if isinstance(item, dict) else item
-                   for item in t.get('identifiers', [])]
+        all_ids = [
+            item['id'] if isinstance(item, dict) else item
+            for item in t.get('identifiers', [])
+        ]
 
         if not all_ids:
             # 식별자가 없는 태스크(예: 단순 블록 연결용): 블록이 하나라도 있으면 배치 완료로 간주
@@ -351,7 +373,11 @@ def get_queue_tasks(users_map, locations_map, version_id=None):
         exam_no = t.get('exam_no')
         task_item['exam_no'] = exam_no
         doc_nm = t.get('doc_name', '')
-        task_item['display_name'] = f'{doc_nm} ({exam_no}차)' if exam_no is not None and exam_no != 1 else doc_nm
+        task_item['display_name'] = (
+            f'{doc_nm} ({exam_no}차)'
+            if exam_no is not None and exam_no != 1
+            else doc_nm
+        )
 
         # 담당자 이름/색상 추가 (값 자체가 이름)
         raw_assignee_names = t.get('assignee_names', [])
@@ -366,8 +392,12 @@ def get_queue_tasks(users_map, locations_map, version_id=None):
                 resolved_names.append(name)
                 resolved_colors.append('#6c757d')
 
-        task_item['assignee_name'] = ', '.join(resolved_names) if resolved_names else '(미배정)'
-        task_item['assignee_color'] = resolved_colors[0] if resolved_colors else '#6c757d'
+        task_item['assignee_name'] = (
+            ', '.join(resolved_names) if resolved_names else '(미배정)'
+        )
+        task_item['assignee_color'] = (
+            resolved_colors[0] if resolved_colors else '#6c757d'
+        )
 
         # 장소 정보 추가
         loc = locations_map.get(t.get('location_id'))
@@ -377,8 +407,12 @@ def get_queue_tasks(users_map, locations_map, version_id=None):
         queue.append(task_item)
 
     # 문서명 → 문서ID → 차수 순으로 정렬
-    queue.sort(key=lambda t: (t.get('doc_name', '') or str(t.get('doc_id', '')),
-                               t.get('exam_no') or 0))
+    queue.sort(
+        key=lambda t: (
+            t.get('doc_name', '') or str(t.get('doc_id', '')),
+            t.get('exam_no') or 0,
+        )
+    )
     return queue
 
 
@@ -458,11 +492,13 @@ def build_month_weeks(year, month, blocks_by_date):
                 week_data.append(None)
             else:
                 d = date(year, month, day_num)
-                week_data.append({
-                    'date': d,
-                    'day': day_num,
-                    'blocks': blocks_by_date.get(d.isoformat(), []),
-                })
+                week_data.append(
+                    {
+                        'date': d,
+                        'day': day_num,
+                        'blocks': blocks_by_date.get(d.isoformat(), []),
+                    }
+                )
         weeks.append(week_data)
     return weeks
 
@@ -477,6 +513,7 @@ def parse_date(date_str):
         date: 파싱된 날짜 객체 또는 오늘 날짜.
     """
     from datetime import datetime
+
     if date_str:
         try:
             return datetime.strptime(date_str, '%Y-%m-%d').date()

--- a/app/features/schedule/services/export.py
+++ b/app/features/schedule/services/export.py
@@ -14,12 +14,20 @@ from xml.sax.saxutils import escape
 
 # 내보내기 열 헤더 (기존 Excel 양식)
 HEADERS = ['날짜', '문서명']
+PRACTITIONER_HEADERS = ['날짜', '장소', '시작', '종료', '절차서', '시험 식별자']
+
 
 def _block_to_row(b):
     """블록 딕셔너리를 내보내기용 행(row) 데이터로 변환한다."""
     name = b.get('display_name') or b.get('doc_name', '') or b.get('task_title', '')
     if b.get('is_split'):
-        name += ' (' + str(b.get('block_identifier_count', '?')) + '/' + str(b.get('total_identifier_count', '?')) + ')'
+        name += (
+            ' ('
+            + str(b.get('block_identifier_count', '?'))
+            + '/'
+            + str(b.get('total_identifier_count', '?'))
+            + ')'
+        )
     return [b.get('date', ''), name]
 
 
@@ -27,8 +35,71 @@ def _block_label(b):
     """블록의 표시 라벨을 생성한다 (달력 시트용)."""
     name = b.get('display_name') or b.get('doc_name', '') or b.get('task_title', '')
     if b.get('is_split'):
-        name += ' (' + str(b.get('block_identifier_count', '?')) + '/' + str(b.get('total_identifier_count', '?')) + ')'
+        name += (
+            ' ('
+            + str(b.get('block_identifier_count', '?'))
+            + '/'
+            + str(b.get('total_identifier_count', '?'))
+            + ')'
+        )
     return name
+
+
+def _identifier_label(identifier):
+    if isinstance(identifier, dict):
+        identifier_id = identifier.get('id', '')
+        identifier_name = identifier.get('name', '')
+        if identifier_id and identifier_name:
+            return f'{identifier_id} - {identifier_name}'
+        return identifier_id or identifier_name
+    return str(identifier) if identifier is not None else ''
+
+
+def _block_identifiers(b):
+    identifiers = b.get('identifiers') or []
+    selected_ids = b.get('identifier_ids')
+    if selected_ids is None:
+        return identifiers
+
+    selected_id_set = set(selected_ids)
+    return [
+        identifier
+        for identifier in identifiers
+        if (
+            identifier.get('id') if isinstance(identifier, dict) else identifier
+        )
+        in selected_id_set
+    ]
+
+
+def _practitioner_rows(enriched_blocks):
+    rows = [PRACTITIONER_HEADERS]
+    sorted_blocks = sorted(
+        enriched_blocks,
+        key=lambda b: (
+            b.get('date', ''),
+            b.get('location_name', ''),
+            b.get('start_time', ''),
+            b.get('end_time', ''),
+            _block_label(b),
+        ),
+    )
+    for b in sorted_blocks:
+        identifiers = _block_identifiers(b)
+        if not identifiers:
+            identifiers = ['']
+        for identifier in identifiers:
+            rows.append(
+                [
+                    b.get('date', ''),
+                    b.get('location_name', ''),
+                    b.get('start_time', ''),
+                    b.get('end_time', ''),
+                    _block_label(b),
+                    _identifier_label(identifier),
+                ]
+            )
+    return rows
 
 
 def _sheet_xml(rows, styled_rows=None):
@@ -49,15 +120,15 @@ def _sheet_xml(rows, styled_rows=None):
             ref = f'{col_name(c_idx)}{r_idx}'
             text = escape(str(value) if value is not None else '')
             style_attr = f' s="{style}"' if style else ''
-            cells.append(f'<c r="{ref}" t="inlineStr"{style_attr}><is><t>{text}</t></is></c>')
+            cells.append(
+                f'<c r="{ref}" t="inlineStr"{style_attr}><is><t>{text}</t></is></c>'
+            )
         xml_rows.append(f'<row r="{r_idx}">{"".join(cells)}</row>')
     return (
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
         '<sheetViews><sheetView workbookViewId="0"><pane ySplit="1" topLeftCell="A2" activePane="bottomLeft" state="frozen"/></sheetView></sheetViews>'
-        '<sheetData>'
-        + ''.join(xml_rows) +
-        '</sheetData></worksheet>'
+        '<sheetData>' + ''.join(xml_rows) + '</sheetData></worksheet>'
     )
 
 
@@ -69,62 +140,92 @@ def _export_xlsx_stdlib(enriched_blocks, start_date, end_date, version_name=''):
     for b in enriched_blocks:
         blocks_by_date.setdefault(b.get('date', ''), []).append(b)
 
-    calendar_rows = [[f'스케줄: {start_date} ~ {end_date}' + (f' / {version_name}' if version_name else '')]]
+    calendar_rows = [
+        [
+            f'스케줄: {start_date} ~ {end_date}'
+            + (f' / {version_name}' if version_name else '')
+        ]
+    ]
     day_names = ['월', '화', '수', '목', '금', '토', '일']
     calendar_rows.append(day_names)
     current = d_start
     while current <= d_end:
         week_days = [current + timedelta(days=i) for i in range(7)]
-        calendar_rows.append([
-            day.strftime('%m/%d') if d_start <= day <= d_end else ''
-            for day in week_days
-        ])
+        calendar_rows.append(
+            [
+                day.strftime('%m/%d') if d_start <= day <= d_end else ''
+                for day in week_days
+            ]
+        )
         max_blocks = max(
             [len(blocks_by_date.get(day.isoformat(), [])) for day in week_days] + [1]
         )
         for block_idx in range(max_blocks):
-            calendar_rows.append([
-                _block_label(blocks_by_date.get(day.isoformat(), [])[block_idx])
-                if block_idx < len(blocks_by_date.get(day.isoformat(), []))
-                else ''
-                for day in week_days
-            ])
+            calendar_rows.append(
+                [
+                    _block_label(blocks_by_date.get(day.isoformat(), [])[block_idx])
+                    if block_idx < len(blocks_by_date.get(day.isoformat(), []))
+                    else ''
+                    for day in week_days
+                ]
+            )
         calendar_rows.append([''] * 7)
         current += timedelta(days=7)
 
     data_rows = [HEADERS] + [_block_to_row(b) for b in enriched_blocks]
+    practitioner_rows = _practitioner_rows(enriched_blocks)
     calendar_styles = {1: 1, 2: 1}
     data_styles = {1: 1}
+    practitioner_styles = {1: 1}
 
-    styles_xml = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    styles_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <fonts count="2"><font><sz val="11"/><name val="Calibri"/></font><font><b/><sz val="11"/><color rgb="FFFFFFFF"/><name val="Calibri"/></font></fonts>
   <fills count="3"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill><fill><patternFill patternType="solid"><fgColor rgb="FF4472C4"/><bgColor indexed="64"/></patternFill></fill></fills>
   <borders count="2"><border/><border><left style="thin"/><right style="thin"/><top style="thin"/><bottom style="thin"/></border></borders>
   <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
   <cellXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyBorder="1" applyAlignment="1"><alignment vertical="top" wrapText="1"/></xf><xf numFmtId="0" fontId="1" fillId="2" borderId="1" xfId="0" applyFont="1" applyFill="1" applyBorder="1" applyAlignment="1"><alignment horizontal="center" vertical="center" wrapText="1"/></xf></cellXfs>
-</styleSheet>'''
+</styleSheet>"""
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as z:
-        z.writestr('[Content_Types].xml', '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        z.writestr(
+            '[Content_Types].xml',
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
   <Default Extension="xml" ContentType="application/xml"/>
   <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
   <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
   <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet3.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
   <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
-</Types>''')
-        z.writestr('_rels/.rels', '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>''')
-        z.writestr('xl/workbook.xml', '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="스케줄" sheetId="1" r:id="rId1"/><sheet name="데이터" sheetId="2" r:id="rId2"/></sheets></workbook>''')
-        z.writestr('xl/_rels/workbook.xml.rels', '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>''')
+</Types>""",
+        )
+        z.writestr(
+            '_rels/.rels',
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>""",
+        )
+        z.writestr(
+            'xl/workbook.xml',
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="스케줄" sheetId="1" r:id="rId1"/><sheet name="데이터" sheetId="2" r:id="rId2"/><sheet name="실무자용" sheetId="3" r:id="rId3"/></sheets></workbook>""",
+        )
+        z.writestr(
+            'xl/_rels/workbook.xml.rels',
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet3.xml"/><Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>""",
+        )
         z.writestr('xl/styles.xml', styles_xml)
-        z.writestr('xl/worksheets/sheet1.xml', _sheet_xml(calendar_rows, calendar_styles))
+        z.writestr(
+            'xl/worksheets/sheet1.xml', _sheet_xml(calendar_rows, calendar_styles)
+        )
         z.writestr('xl/worksheets/sheet2.xml', _sheet_xml(data_rows, data_styles))
+        z.writestr(
+            'xl/worksheets/sheet3.xml',
+            _sheet_xml(practitioner_rows, practitioner_styles),
+        )
     return buf.getvalue()
 
 
@@ -190,15 +291,23 @@ def export_xlsx(enriched_blocks, start_date, end_date, version_name=''):
 
     # 엑셀 스타일 정의
     thin_border = Border(
-        left=Side(style='thin'), right=Side(style='thin'),
-        top=Side(style='thin'), bottom=Side(style='thin'),
+        left=Side(style='thin'),
+        right=Side(style='thin'),
+        top=Side(style='thin'),
+        bottom=Side(style='thin'),
     )
-    header_fill = PatternFill(start_color='4472C4', end_color='4472C4', fill_type='solid')
+    header_fill = PatternFill(
+        start_color='4472C4', end_color='4472C4', fill_type='solid'
+    )
     header_font_white = Font(bold=True, size=11, color='FFFFFF')
     date_font = Font(bold=True, size=10)
     block_font = Font(size=9)
-    today_fill = PatternFill(start_color='E8F4FD', end_color='E8F4FD', fill_type='solid')
-    weekend_fill = PatternFill(start_color='F5F5F5', end_color='F5F5F5', fill_type='solid')
+    today_fill = PatternFill(
+        start_color='E8F4FD', end_color='E8F4FD', fill_type='solid'
+    )
+    weekend_fill = PatternFill(
+        start_color='F5F5F5', end_color='F5F5F5', fill_type='solid'
+    )
     center_align = Alignment(horizontal='center', vertical='top', wrap_text=True)
     top_align = Alignment(vertical='top', wrap_text=True)
     today = date.today()
@@ -273,7 +382,9 @@ def export_xlsx(enriched_blocks, start_date, end_date, version_name=''):
                         g_c = int(int(color_hex[2:4], 16) * 0.3 + 255 * 0.7)
                         b_c = int(int(color_hex[4:6], 16) * 0.3 + 255 * 0.7)
                         light = f'{r_c:02X}{g_c:02X}{b_c:02X}'
-                        cell.fill = PatternFill(start_color=light, end_color=light, fill_type='solid')
+                        cell.fill = PatternFill(
+                            start_color=light, end_color=light, fill_type='solid'
+                        )
 
         for r_offset in range(content_rows):
             ws.row_dimensions[row + r_offset].height = 60
@@ -296,6 +407,27 @@ def export_xlsx(enriched_blocks, start_date, end_date, version_name=''):
             val = str(cell.value) if cell.value else ''
             max_len = max(max_len, len(val))
         ws2.column_dimensions[col[0].column_letter].width = max_len + 4
+
+    # 세 번째 시트: 실무자용 날짜/장소/식별자 목록
+    ws3 = wb.create_sheet(title='실무자용')
+    for row_values in _practitioner_rows(enriched_blocks):
+        ws3.append(row_values)
+    for cell in ws3[1]:
+        cell.font = header_font_white
+        cell.fill = header_fill
+        cell.alignment = center_align
+        cell.border = thin_border
+    for row_cells in ws3.iter_rows(min_row=2):
+        for cell in row_cells:
+            cell.alignment = top_align
+            cell.border = thin_border
+    ws3.freeze_panes = 'A2'
+    for col in ws3.columns:
+        max_len = 0
+        for cell in col:
+            val = str(cell.value) if cell.value else ''
+            max_len = max(max_len, len(val))
+        ws3.column_dimensions[col[0].column_letter].width = min(max_len + 4, 60)
 
     # 워크북을 바이트 버퍼에 저장하여 반환
     buf = io.BytesIO()

--- a/tests/test_routes_calendar.py
+++ b/tests/test_routes_calendar.py
@@ -1,9 +1,13 @@
 """Tests for calendar/schedule routes."""
+
 import zipfile
 from io import BytesIO
 
 from tests.conftest import (
-    _create_user, _create_location, _create_task, _create_version, _create_block,
+    _create_user,
+    _create_location,
+    _create_task,
+    _create_block,
 )
 
 
@@ -66,21 +70,28 @@ class TestScheduleBlockAPI:
         """If no assignee_names, use the task's assignee_names."""
         uid = _create_user(client)
         tid = _create_task(client, uid)
-        r = client.post('/schedule/api/blocks', json={
-            'task_id': tid, 'date': '2026-03-10',
-            'start_time': '09:00', 'end_time': '10:00',
-        })
+        r = client.post(
+            '/schedule/api/blocks',
+            json={
+                'task_id': tid,
+                'date': '2026-03-10',
+                'start_time': '09:00',
+                'end_time': '10:00',
+            },
+        )
         assert r.status_code == 201
         assert uid in r.get_json()['assignee_names']
 
     def test_create_block_overlap_rejected(self, client):
         uid = _create_user(client)
         tid = _create_task(client, uid)
-        _create_block(client, tid, uid, start='09:00', end='10:00',
-                      location_id='loc_test')
+        _create_block(
+            client, tid, uid, start='09:00', end='10:00', location_id='loc_test'
+        )
         # Overlapping block at same location
-        _, status = _create_block(client, tid, uid, start='09:30', end='10:30',
-                                  location_id='loc_test')
+        _, status = _create_block(
+            client, tid, uid, start='09:30', end='10:30', location_id='loc_test'
+        )
         assert status == 409
 
     def test_create_block_adjacent_allowed(self, client):
@@ -97,7 +108,11 @@ class TestScheduleBlockAPI:
         uid = _create_user(client)
         tid = _create_task(client, uid)
         data, status = _create_block(
-            client, tid, uid, start='11:00', end='14:00',
+            client,
+            tid,
+            uid,
+            start='11:00',
+            end='14:00',
         )
         assert status == 201
         # 3h work: 11:00-12:00 (1h) + skip lunch + 13:00-15:00 (2h) = end at 15:00
@@ -107,9 +122,13 @@ class TestScheduleBlockAPI:
         uid = _create_user(client)
         tid = _create_task(client, uid)
         block, _ = _create_block(client, tid, uid)
-        r = client.put(f'/schedule/api/blocks/{block["id"]}', json={
-            'start_time': '10:00', 'end_time': '11:00',
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{block["id"]}',
+            json={
+                'start_time': '10:00',
+                'end_time': '11:00',
+            },
+        )
         assert r.status_code == 200
         assert r.get_json()['start_time'] == '10:00'
 
@@ -117,9 +136,12 @@ class TestScheduleBlockAPI:
         uid = _create_user(client)
         tid = _create_task(client, uid)
         block, _ = _create_block(client, tid, uid, date_str='2026-03-10')
-        r = client.put(f'/schedule/api/blocks/{block["id"]}', json={
-            'date': '2026-03-11',
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{block["id"]}',
+            json={
+                'date': '2026-03-11',
+            },
+        )
         assert r.status_code == 200
         assert r.get_json()['date'] == '2026-03-11'
 
@@ -130,9 +152,13 @@ class TestScheduleBlockAPI:
         # Create 1h block at 09:00-10:00
         block, _ = _create_block(client, tid, uid, start='09:00', end='10:00')
         # Move to 11:00 -- should still be 1h of work
-        r = client.put(f'/schedule/api/blocks/{block["id"]}', json={
-            'start_time': '11:00', 'end_time': '12:00',
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{block["id"]}',
+            json={
+                'start_time': '11:00',
+                'end_time': '12:00',
+            },
+        )
         data = r.get_json()
         assert data['start_time'] == '11:00'
         assert data['end_time'] == '12:00'
@@ -142,9 +168,13 @@ class TestScheduleBlockAPI:
         uid = _create_user(client)
         tid = _create_task(client, uid)
         block, _ = _create_block(client, tid, uid, start='09:00', end='10:00')
-        r = client.put(f'/schedule/api/blocks/{block["id"]}', json={
-            'start_time': '11:30', 'end_time': '12:30',
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{block["id"]}',
+            json={
+                'start_time': '11:30',
+                'end_time': '12:30',
+            },
+        )
         data = r.get_json()
         assert data['start_time'] == '11:30'
         # 1h work: 11:30-12:00 (30min) + skip lunch + 13:00-13:30 (30min) = 13:30
@@ -155,10 +185,14 @@ class TestScheduleBlockAPI:
         uid = _create_user(client)
         tid = _create_task(client, uid)
         block, _ = _create_block(client, tid, uid, start='09:00', end='10:00')
-        r = client.put(f'/schedule/api/blocks/{block["id"]}', json={
-            'start_time': '09:00', 'end_time': '09:30',
-            'resize': True,
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{block["id"]}',
+            json={
+                'start_time': '09:00',
+                'end_time': '09:30',
+                'resize': True,
+            },
+        )
         assert r.get_json()['end_time'] == '09:30'
 
     def test_update_block_resize_syncs_remaining(self, client):
@@ -169,10 +203,14 @@ class TestScheduleBlockAPI:
         t_before = client.get(f'/tasks/api/{tid}').get_json()['task']
         rem_before = t_before['remaining_minutes']
         # Resize to 1h — remaining should increase
-        r = client.put(f'/schedule/api/blocks/{block["id"]}', json={
-            'start_time': '09:00', 'end_time': '10:00',
-            'resize': True,
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{block["id"]}',
+            json={
+                'start_time': '09:00',
+                'end_time': '10:00',
+                'resize': True,
+            },
+        )
         assert 'split_block' not in r.get_json()
         t = client.get(f'/tasks/api/{tid}').get_json()['task']
         assert t['estimated_minutes'] == 240
@@ -180,21 +218,37 @@ class TestScheduleBlockAPI:
 
     def test_update_block_overlap_rejected(self, client):
         # Create two simple blocks (different tasks) at same location
-        r1 = client.post('/schedule/api/blocks', json={
-            'is_simple': True, 'date': '2026-03-10',
-            'start_time': '10:00', 'end_time': '11:00',
-            'location_id': 'loc_test', 'title': 'A',
-        })
-        r2 = client.post('/schedule/api/blocks', json={
-            'is_simple': True, 'date': '2026-03-10',
-            'start_time': '11:00', 'end_time': '11:30',
-            'location_id': 'loc_test', 'title': 'B',
-        })
+        client.post(
+            '/schedule/api/blocks',
+            json={
+                'is_simple': True,
+                'date': '2026-03-10',
+                'start_time': '10:00',
+                'end_time': '11:00',
+                'location_id': 'loc_test',
+                'title': 'A',
+            },
+        )
+        r2 = client.post(
+            '/schedule/api/blocks',
+            json={
+                'is_simple': True,
+                'date': '2026-03-10',
+                'start_time': '11:00',
+                'end_time': '11:30',
+                'location_id': 'loc_test',
+                'title': 'B',
+            },
+        )
         b2_id = r2.get_json()['id']
         # Try to move b2 to overlap with b1
-        r = client.put(f'/schedule/api/blocks/{b2_id}', json={
-            'start_time': '10:00', 'end_time': '10:30',
-        })
+        r = client.put(
+            f'/schedule/api/blocks/{b2_id}',
+            json={
+                'start_time': '10:00',
+                'end_time': '10:30',
+            },
+        )
         assert r.status_code == 409
 
     def test_update_nonexistent_block(self, client):
@@ -317,6 +371,7 @@ class TestScheduleViewAPIs:
         tid = _create_task(client, uid, hours='2')
 
         from app.features.execution.models.execution import ExecutionRepository
+
         with app.app_context():
             ex1 = ExecutionRepository.start('TC-001', tid)
             ExecutionRepository.complete(ex1['id'], fail_count=0)
@@ -335,10 +390,12 @@ class TestOverlapLayout:
         uid2 = _create_user(client, name='김철수', color='#FF0000')
         tid2 = _create_task(client, uid2, doc_id=771)
         # Two blocks at same time, different assignees
-        _create_block(client, tid1, uid, date_str='2026-03-10',
-                      start='09:00', end='10:00')
-        _create_block(client, tid2, uid2, date_str='2026-03-10',
-                      start='09:00', end='10:00')
+        _create_block(
+            client, tid1, uid, date_str='2026-03-10', start='09:00', end='10:00'
+        )
+        _create_block(
+            client, tid2, uid2, date_str='2026-03-10', start='09:00', end='10:00'
+        )
         r = client.get('/schedule/api/day?date=2026-03-10')
         # API doesn't compute overlap layout, but template view does
         r = client.get('/schedule/?date=2026-03-10')
@@ -351,7 +408,6 @@ class TestOverlapLayout:
         _create_block(client, tid, uid, start='10:00', end='11:00')
         r = client.get('/schedule/?date=2026-03-10')
         assert r.status_code == 200
-
 
 
 class TestExportAPI:
@@ -370,8 +426,26 @@ class TestExportAPI:
 
     def test_export_xlsx(self, client):
         uid = _create_user(client)
-        tid = _create_task(client, uid)
-        _create_block(client, tid, uid, date_str='2026-03-10')
+        loc_id = _create_location(client, name='A 시험실')
+        tid = _create_task(client, uid, loc_id=loc_id)
+        _create_block(
+            client,
+            tid,
+            uid,
+            date_str='2026-03-10',
+            location_id=loc_id,
+            identifier_ids=['TC-001'],
+        )
+        _create_block(
+            client,
+            tid,
+            uid,
+            date_str='2026-03-11',
+            start='10:00',
+            end='11:00',
+            location_id=loc_id,
+            identifier_ids=['TC-002'],
+        )
         r = client.get(
             '/schedule/api/export?start_date=2026-03-10&end_date=2026-03-16&format=xlsx'
         )
@@ -382,11 +456,22 @@ class TestExportAPI:
             names = set(z.namelist())
             assert 'xl/worksheets/sheet1.xml' in names
             assert 'xl/worksheets/sheet2.xml' in names
+            assert 'xl/worksheets/sheet3.xml' in names
             assert 'xl/styles.xml' in names
+            workbook = z.read('xl/workbook.xml').decode('utf-8')
+            assert '실무자용' in workbook
             data_sheet = z.read('xl/worksheets/sheet2.xml').decode('utf-8')
             assert '날짜' in data_sheet
             assert '문서명' in data_sheet
             assert '시스템' in data_sheet
+            practitioner_sheet = z.read('xl/worksheets/sheet3.xml').decode('utf-8')
+            assert '장소' in practitioner_sheet
+            assert '절차서' in practitioner_sheet
+            assert '시험 식별자' in practitioner_sheet
+            assert 'A 시험실' in practitioner_sheet
+            assert 'TC-001' in practitioner_sheet
+            assert 'TC-002' in practitioner_sheet
+            assert practitioner_sheet.count('시스템') == 2
 
     def test_export_empty_range(self, client):
         r = client.get(
@@ -399,9 +484,7 @@ class TestExportAPI:
         assert r.status_code == 400
 
     def test_export_invalid_date(self, client):
-        r = client.get(
-            '/schedule/api/export?start_date=bad&end_date=2026-03-10'
-        )
+        r = client.get('/schedule/api/export?start_date=bad&end_date=2026-03-10')
         assert r.status_code == 400
 
     def test_export_csv_has_headers(self, client):


### PR DESCRIPTION
## Summary

- Add a third Excel sheet named `실무자용` to schedule XLSX exports.
- List rows by date, location, block time, procedure, and test identifier.
- Include split block identifiers so procedures spanning multiple dates appear on each scheduled date.

Closes #144

## Validation

- `python3 -m pytest -q`
