### PR TITLE
Fix execution result count inputs

### DIFF
--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -337,9 +337,9 @@ function renderPage() {
     const dis    = !started ? 'disabled' : '';
     const failV  = started ? ex.fail_count      : 0;
     const blockV = started ? (ex.block_count ?? 0) : 0;
-    const total  = started ? ex.total_count     : 0;
+    const total  = started ? (Number(ex.total_count) || 0) : 0;
     const passV  = started ? Math.max(0, total - failV - blockV) : 0;
-    const maxA   = started ? `max="${total}"`   : '';
+    const maxA   = total > 0 ? `max="${total}"` : '';
     failPassHtml = `
     <div class="exec-counts-bar mb-3">
       <div class="exec-count-cell" style="background:#fef2f2">
@@ -582,7 +582,7 @@ async function doSaveComment() {
  */
 function updatePass() {
   if (!_item?.execution) return;
-  const total = _item.execution.total_count;
+  const total = Number(_item.execution.total_count) || 0;
   const fail  = parseInt(document.getElementById('fail-input')?.value  || 0) || 0;
   const block = parseInt(document.getElementById('block-input')?.value || 0) || 0;
   document.getElementById('pass-display').textContent = Math.max(0, total - fail - block);

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -222,6 +222,36 @@ class TestExecutionAPI:
         assert data['status'] == 'completed'
         assert data['fail_count'] == 3
 
+    def test_complete_accepts_result_counts_when_total_count_unknown(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.schedule.models import task as task_repo
+
+            task = task_repo.create(
+                doc_id=5,
+                assignee_names=[],
+                location_id='',
+                doc_name='카운트 미정 문서',
+                identifiers=[
+                    {'id': 'TC-UNKNOWN', 'name': '카운트 미정 시험', 'estimated_minutes': 10},
+                ],
+                estimated_minutes=10,
+            )
+
+        r = exec_client.post('/execution/api/start', json={
+            'identifier_id': 'TC-UNKNOWN', 'task_id': task['id']
+        })
+        ex_id = r.get_json()['id']
+        r2 = exec_client.post('/execution/api/complete', json={
+            'execution_id': ex_id, 'fail_count': 2, 'block_count': 1
+        })
+
+        assert r2.status_code == 200
+        data = r2.get_json()
+        assert data['total_count'] == 0
+        assert data['fail_count'] == 2
+        assert data['block_count'] == 1
+        assert data['pass_count'] == 0
+
     def test_reset(self, exec_client):
         r = exec_client.post('/execution/api/start', json={
             'identifier_id': 'TC-001', 'task_id': 't_001'
@@ -342,3 +372,18 @@ class TestExecutionAPI:
     def test_execution_page(self, exec_client):
         r = exec_client.get('/execution/')
         assert r.status_code == 200
+
+    def test_detail_count_inputs_only_cap_when_total_count_is_known(self):
+        js_path = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            'app',
+            'static',
+            'execution',
+            'js',
+            'execution-detail.js',
+        )
+        with open(js_path) as f:
+            detail_js = f.read()
+
+        assert 'const maxA   = total > 0 ? `max="${total}"` : \'\';' in detail_js


### PR DESCRIPTION
## Summary
- Allow FAIL/BLOCK inputs to increase when `total_count` is unknown or zero
- Keep the existing max cap only when a positive total count is known
- Add regression coverage for unknown total-count completion and the detail-page input cap

Closes #146

## Tests
- `python3 -m pytest tests/test_execution.py`
- `python3 -m pytest`
