### PR TITLE
Fix execution total count propagation

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -65,20 +65,38 @@ def _notify_timing(identifier_id: str, task_id: str, elapsed_seconds: int):
     threading.Thread(target=_send, daemon=True).start()
 
 
+TOTAL_COUNT_KEYS = (
+    'total_count',
+    'test_count',
+    'case_count',
+    'count',
+    'total_tests',
+    'total_cases',
+    'test_case_count',
+    'testcase_count',
+    'tc_count',
+)
+
+
+def _coerce_count(value) -> int | None:
+    if value in (None, ''):
+        return None
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return None
+
+
 def _identifier_total_count(identifier: dict) -> int:
     """식별자 데이터에 저장된 전체 시험 건수를 반환한다.
 
     외부 API 연동 전까지 10을 고정 반환하던 값이 결과를 오염시키지 않도록,
     동기화 데이터에 명시된 카운트 필드를 우선 사용하고 없으면 0으로 둔다.
     """
-    for key in ('total_count', 'test_count', 'case_count', 'count'):
-        value = identifier.get(key)
-        if value in (None, ''):
-            continue
-        try:
-            return max(0, int(value))
-        except (TypeError, ValueError):
-            continue
+    for key in TOTAL_COUNT_KEYS:
+        value = _coerce_count(identifier.get(key))
+        if value is not None:
+            return value
     return 0
 
 
@@ -94,7 +112,7 @@ def _get_total_count(identifier_id: str, task_id: str = '') -> int:
     return 0
 
 
-def _execution_response(ex):
+def _execution_response(ex, fallback_total_count=0):
     """실행 레코드를 API 응답용 딕셔너리로 변환한다.
 
     elapsed_seconds는 저장된 스냅샷 값 대신 segments로부터 실시간 재계산하여
@@ -105,12 +123,15 @@ def _execution_response(ex):
     """
     if ex is None:
         return None
+    total_count = _coerce_count(ex.get('total_count')) or 0
+    if total_count == 0 and fallback_total_count:
+        total_count = fallback_total_count
     return {
         'id': ex['id'],
         'status': ex['status'],
         # segments 기반 실시간 계산 — 저장된 elapsed_seconds 필드는 스냅샷용
         'elapsed_seconds': ExecutionRepository.compute_elapsed_seconds(ex.get('segments', [])),
-        'total_count': ex.get('total_count', 0),
+        'total_count': total_count,
         'fail_count': ex.get('fail_count', 0),
         'block_count': ex.get('block_count', 0),
         'pass_count': ex.get('pass_count', 0),
@@ -188,6 +209,7 @@ def _build_item_dict(task, identifier, locations, scheduled_date, block_loc_id='
     # 블록 장소가 있으면 우선, 없으면 태스크 장소로 폴백
     loc_id = block_loc_id or task.get('location_id', '')
     loc_name = locations.get(loc_id, {}).get('name', '') if loc_id else ''
+    total_count = _identifier_total_count(identifier)
     execution = ExecutionRepository.get_by_identifier_and_task(iid, task['id'])
     completed_at = execution.get('completed_at') if execution else None
     exam_no = task.get('exam_no')
@@ -206,9 +228,9 @@ def _build_item_dict(task, identifier, locations, scheduled_date, block_loc_id='
         'location_name': loc_name,
         'scheduled_date': scheduled_date,
         'display_date': completed_at or scheduled_date,
-        'total_count': _identifier_total_count(identifier),
+        'total_count': total_count,
         # 실행 레코드가 없으면 None (미시작 상태를 프론트에서 pending으로 표시)
-        'execution': _execution_response(execution),
+        'execution': _execution_response(execution, total_count),
     }
 
 
@@ -373,6 +395,13 @@ def complete():
     block_count = body.get('block_count', 0)
     if not execution_id:
         return jsonify({'error': 'execution_id required'}), 400
+    current = ExecutionRepository.get_by_id(execution_id)
+    if current and (_coerce_count(current.get('total_count')) or 0) == 0:
+        total_count = _get_total_count(
+            current.get('identifier_id', ''), current.get('task_id', '')
+        )
+        if total_count:
+            ExecutionRepository._patch(execution_id, total_count=total_count)
     ex = ExecutionRepository.complete(execution_id, fail_count, block_count)
     if ex is None:
         return jsonify({'error': 'not found or invalid state'}), 404

--- a/app/features/schedule/providers/dyn_ready.py
+++ b/app/features/schedule/providers/dyn_ready.py
@@ -14,6 +14,17 @@ from app.features.schedule.providers.base import BaseProvider, NoChangesError
 
 _ENDPOINT = '/dyn_ready/std-list/grouped'
 _META_FILE = 'dyn_ready_meta.json'
+_TOTAL_COUNT_KEYS = (
+    'total_count',
+    'test_count',
+    'case_count',
+    'count',
+    'total_tests',
+    'total_cases',
+    'test_case_count',
+    'testcase_count',
+    'tc_count',
+)
 
 
 def _meta_path():
@@ -47,6 +58,18 @@ def _data_hash(payload):
         separators=(',', ':'),
     )
     return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
+
+
+def _first_count(ident):
+    for key in _TOTAL_COUNT_KEYS:
+        value = ident.get(key)
+        if value in (None, ''):
+            continue
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 class DynReadyProvider(BaseProvider):
@@ -109,6 +132,9 @@ def _transform(payload):
                 'estimated_minutes': ident.get('estimated_minutes', 0),
                 'owners': [ident['owner']] if ident.get('owner') else [],
             }
+            total_count = _first_count(ident)
+            if total_count is not None:
+                normalized['total_count'] = total_count
             by_exam.setdefault(exam_no, []).append(normalized)
 
         for exam_no, idents in by_exam.items():

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -239,6 +239,7 @@ function renderPage() {
   const cfg    = STATUS_CFG[status] || STATUS_CFG.pending;
 
   const assignee = (item.assignee_names || []).join(', ') || '-';
+  const totalCount = Number(ex?.total_count) || Number(item.total_count) || 0;
 
   const leftPanel = `
   <div class="exec-detail-sidebar">
@@ -275,9 +276,9 @@ function renderPage() {
           <div class="sidebar-field-label">예상시간</div>
           <div class="sidebar-field-value">${formatMinutes(item.estimated_minutes)}</div>
         </div>
-        ${ex ? `<div class="sidebar-field">
+        ${totalCount ? `<div class="sidebar-field">
           <div class="sidebar-field-label">총 건수</div>
-          <div class="sidebar-field-value">${ex.total_count}건</div>
+          <div class="sidebar-field-value">${totalCount}건</div>
         </div>` : ''}
       </div>
     </div>
@@ -329,7 +330,7 @@ function renderPage() {
       </div>
       <div class="exec-count-cell" style="background:#f8fafc">
         <div class="exec-count-label text-muted">총 건수</div>
-        <div class="exec-count-value text-secondary">${ex.total_count}</div>
+        <div class="exec-count-value text-secondary">${totalCount}</div>
       </div>
     </div>`;
   } else {
@@ -337,7 +338,7 @@ function renderPage() {
     const dis    = !started ? 'disabled' : '';
     const failV  = started ? ex.fail_count      : 0;
     const blockV = started ? (ex.block_count ?? 0) : 0;
-    const total  = started ? (Number(ex.total_count) || 0) : 0;
+    const total  = started ? totalCount : Number(item.total_count) || 0;
     const passV  = started ? Math.max(0, total - failV - blockV) : 0;
     const maxA   = total > 0 ? `max="${total}"` : '';
     failPassHtml = `
@@ -582,7 +583,7 @@ async function doSaveComment() {
  */
 function updatePass() {
   if (!_item?.execution) return;
-  const total = Number(_item.execution.total_count) || 0;
+  const total = Number(_item.execution.total_count) || Number(_item.total_count) || 0;
   const fail  = parseInt(document.getElementById('fail-input')?.value  || 0) || 0;
   const block = parseInt(document.getElementById('block-input')?.value || 0) || 0;
   document.getElementById('pass-display').textContent = Math.max(0, total - fail - block);

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -293,6 +293,74 @@ class TestExecutionAPI:
         assert r.status_code == 200
         assert r.get_json()['total_count'] == 7
 
+    def test_total_count_accepts_external_aliases(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.schedule.models import task as task_repo
+
+            task_repo.create(
+                doc_id=6,
+                assignee_names=[],
+                location_id='',
+                doc_name='별칭 카운트 문서',
+                identifiers=[
+                    {'id': 'TC-ALIAS', 'name': '별칭 시험', 'estimated_minutes': 10, 'total_tests': 11},
+                ],
+                estimated_minutes=10,
+            )
+
+        r = exec_client.get('/execution/api/total-count/TC-ALIAS')
+        assert r.status_code == 200
+        assert r.get_json()['total_count'] == 11
+
+    def test_item_uses_identifier_total_count_when_execution_has_zero(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.execution.models.execution import ExecutionRepository
+            from app.features.schedule.models import task as task_repo
+
+            task = task_repo.create(
+                doc_id=7,
+                assignee_names=[],
+                location_id='',
+                doc_name='총 건수 보정 문서',
+                identifiers=[
+                    {'id': 'TC-FALLBACK', 'name': '보정 시험', 'estimated_minutes': 10, 'total_count': 6},
+                ],
+                estimated_minutes=10,
+            )
+            ExecutionRepository.start('TC-FALLBACK', task['id'], total_count=0)
+
+        r = exec_client.get('/execution/api/item/TC-FALLBACK?task_id=' + task['id'])
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data['total_count'] == 6
+        assert data['execution']['total_count'] == 6
+
+    def test_complete_rehydrates_total_count_before_pass_calculation(self, exec_app, exec_client):
+        with exec_app.app_context():
+            from app.features.execution.models.execution import ExecutionRepository
+            from app.features.schedule.models import task as task_repo
+
+            task = task_repo.create(
+                doc_id=8,
+                assignee_names=[],
+                location_id='',
+                doc_name='완료 계산 문서',
+                identifiers=[
+                    {'id': 'TC-REHYDRATE', 'name': '완료 계산 시험', 'estimated_minutes': 10, 'total_count': 9},
+                ],
+                estimated_minutes=10,
+            )
+            ex = ExecutionRepository.start('TC-REHYDRATE', task['id'], total_count=0)
+
+        r = exec_client.post('/execution/api/complete', json={
+            'execution_id': ex['id'], 'fail_count': 2, 'block_count': 3
+        })
+
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data['total_count'] == 9
+        assert data['pass_count'] == 4
+
     def test_complete_result_counts_and_completed_date_are_listed(self, exec_app, exec_client):
         with exec_app.app_context():
             from app.features.schedule.models import task as task_repo

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -98,6 +98,27 @@ class TestJsonFileProvider:
 
 
 class TestDynReadyProvider:
+    def test_transform_preserves_total_count(self):
+        from app.features.schedule.providers.dyn_ready import _transform
+
+        payload = {
+            'data': [{
+                'doc_id': 1,
+                'doc_name': '시스템',
+                'identifiers': [{
+                    'test_id': 'TC-001',
+                    'func_name': '전원 시험',
+                    'exam_no': 1,
+                    'estimated_minutes': 30,
+                    'total_tests': 8,
+                }],
+            }],
+        }
+
+        result = _transform(payload)
+
+        assert result[0]['identifiers'][0]['total_count'] == 8
+
     def test_same_timestamp_and_same_data_skips_sync(self, app):
         from unittest.mock import Mock, patch
 


### PR DESCRIPTION
## Summary
- Preserve total-count fields from dyn_ready sync payloads by normalizing them to `total_count`
- Read additional common total-count aliases in the execution API
- Fall back to identifier `total_count` when an existing execution record still has `0`, including completion PASS calculation
- Show the detail-page total count from either execution data or item data

## Tests
- `python3 -m pytest tests/test_execution.py tests/test_providers.py`
- `python3 -m pytest`
