### PR TITLE
Show execution authors from identifier owners

### DIFF
--- a/app/features/execution/routes/api.py
+++ b/app/features/execution/routes/api.py
@@ -201,6 +201,7 @@ def _build_item_dict(task, identifier, locations, scheduled_date, block_loc_id='
         'doc_name': doc_name,
         'display_name': display_name,
         'assignee_names': task.get('assignee_names', []),
+        'owners': identifier.get('owners', []),
         'estimated_minutes': identifier.get('estimated_minutes', 0),
         'location_id': loc_id,
         'location_name': loc_name,

--- a/app/static/execution/js/execution-app.js
+++ b/app/static/execution/js/execution-app.js
@@ -35,7 +35,7 @@ let _sortCol = null;
 /** 정렬 방향. 'asc' 또는 'desc'. */
 let _sortDir = 'asc';
 
-/** 실시간 텍스트 검색어. identifier_id·identifier_name·assignee_names 대상. */
+/** 실시간 텍스트 검색어. identifier_id·identifier_name·owners 대상. */
 let _searchText = '';
 
 /**
@@ -72,7 +72,7 @@ const COL_DEFS = [
   { key: 'doc',        label: '문서' },
   { key: 'identifier', label: '식별자' },
   { key: 'name',       label: '시험항목' },
-  { key: 'assignee',   label: '담당자' },
+  { key: 'assignee',   label: '작성자' },
   { key: 'location',   label: '장소' },
   { key: 'date',       label: '날짜' },
   { key: 'estimated',  label: '예상시간' },
@@ -179,7 +179,7 @@ function buildTableHeader() {
   if (colVisible('doc'))        cols.push('<th style="width:250px">문서</th>');
   if (colVisible('identifier')) cols.push('<th style="width:180px">식별자</th>');
   if (colVisible('name'))       cols.push('<th>시험항목</th>');
-  if (colVisible('assignee'))   cols.push('<th style="width:100px">담당자</th>');
+  if (colVisible('assignee'))   cols.push('<th style="width:100px">작성자</th>');
   if (colVisible('location'))   cols.push('<th class="sortable" data-sort="location" style="width:90px">장소 <i class="bi bi-arrow-down-up ms-1 text-muted"></i></th>');
   if (colVisible('date'))       cols.push('<th class="sortable" data-sort="date" style="width:95px">날짜 <i class="bi bi-arrow-down-up ms-1 text-muted"></i></th>');
   if (colVisible('estimated'))  cols.push('<th style="width:75px">예상</th>');
@@ -275,7 +275,7 @@ function setSort(col) {
  * _allItems에 텍스트 검색과 정렬을 적용한 뒤 renderTable()을 호출한다.
  *
  * 필터:
- *   - 텍스트 검색(_searchText): identifier_id·identifier_name·assignee_names 포함 검색
+ *   - 텍스트 검색(_searchText): identifier_id·identifier_name·owners 포함 검색
  *   - 날짜·장소 필터는 loadList() 단계에서 서버에 파라미터로 전달하므로 여기서는 처리 안 함
  *
  * 정렬:
@@ -289,7 +289,7 @@ function applyAndRender() {
   if (q) items = items.filter(i =>
     i.identifier_id.toLowerCase().includes(q) ||
     i.identifier_name.toLowerCase().includes(q) ||
-    (i.assignee_names || []).some(a => a.toLowerCase().includes(q)));
+    (i.owners || []).some(a => a.toLowerCase().includes(q)));
   if (_sortCol) {
     items.sort((a, b) => {
       let va, vb;
@@ -382,13 +382,13 @@ function renderStatusSummary() {
  * 'name' 열에는 renderCommentIcon()으로 코멘트 아이콘을 추가한다.
  */
 function buildRow(item) {
-  const assignee = (item.assignee_names || []).join(', ') || '-';
+  const owners = (item.owners || []).join(', ') || '-';
   const status = item.execution?.status || 'pending';
   const cells = [];
   if (colVisible('doc'))        cells.push(`<td class="td-doc">${escHtml(item.display_name || item.doc_name || '-')}</td>`);
   if (colVisible('identifier')) cells.push(`<td class="td-id">${escHtml(item.identifier_id)}</td>`);
   if (colVisible('name'))       cells.push(`<td class="td-name">${escHtml(item.identifier_name)}${renderCommentIcon(item)}</td>`);
-  if (colVisible('assignee'))   cells.push(`<td class="td-meta">${escHtml(assignee)}</td>`);
+  if (colVisible('assignee'))   cells.push(`<td class="td-meta">${escHtml(owners)}</td>`);
   if (colVisible('location'))   cells.push(`<td class="td-meta">${escHtml(item.location_name || '-')}</td>`);
   if (colVisible('date'))       cells.push(`<td class="td-meta">${escHtml(item.display_date || item.scheduled_date || '-')}</td>`);
   if (colVisible('estimated'))  cells.push(`<td class="td-meta">${formatMinutes(item.estimated_minutes)}</td>`);

--- a/app/static/execution/js/execution-detail.js
+++ b/app/static/execution/js/execution-detail.js
@@ -227,7 +227,7 @@ function _totalCount(item, ex) {
  *
  * 레이아웃 구조:
  *   .exec-detail-layout
- *     └ 왼쪽 사이드바 (.exec-detail-sidebar): 식별자 정보 + 담당자·날짜·장소 요약
+ *     └ 왼쪽 사이드바 (.exec-detail-sidebar): 식별자 정보 + 작성자·날짜·장소 요약
  *     └ 오른쪽 메인 (.exec-detail-main):
  *         - 타이머 카드 (상태별 배경색, 액션 버튼)
  *         - FAIL/BLOCK/PASS 입력 또는 완료 결과 표시
@@ -243,7 +243,7 @@ function renderPage() {
   const status = ex?.status ?? 'pending';
   const cfg    = STATUS_CFG[status] || STATUS_CFG.pending;
 
-  const assignee = (item.assignee_names || []).join(', ') || '-';
+  const owners = (item.owners || []).join(', ') || '-';
 
   const leftPanel = `
   <div class="exec-detail-sidebar">
@@ -260,8 +260,8 @@ function renderPage() {
         <div class="sidebar-field-value">${escHtml(item.display_name || item.doc_name || '-')}</div>
       </div>
       <div class="sidebar-field">
-        <div class="sidebar-field-label">담당자</div>
-        <div class="sidebar-field-value">${escHtml(assignee)}</div>
+        <div class="sidebar-field-label">작성자</div>
+        <div class="sidebar-field-value">${escHtml(owners)}</div>
       </div>
     </div>
     <div class="sidebar-section">

--- a/app/templates/execution/index.html
+++ b/app/templates/execution/index.html
@@ -43,7 +43,7 @@
       <i class="bi bi-search text-muted" style="font-size:.8rem"></i>
     </span>
     <input id="search-input" type="search" class="form-control border-start-0" style="border-radius:0 8px 8px 0"
-           placeholder="식별자 / 시험항목 / 담당자 검색…">
+           placeholder="식별자 / 시험항목 / 작성자 검색…">
   </div>
   <div class="dropdown ms-auto">
     <button class="btn btn-sm btn-outline-secondary" type="button"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -269,6 +269,34 @@ class TestExecutionAPI:
         assert r.status_code == 200
         assert isinstance(r.get_json(), list)
 
+    def test_list_includes_identifier_owners_for_author_column(
+        self, exec_app, exec_client
+    ):
+        with exec_app.app_context():
+            from app.features.schedule.models import task as task_repo
+
+            task_repo.create(
+                doc_id=1,
+                assignee_names=['테스트 담당자'],
+                location_id='',
+                doc_name='작성자 문서',
+                identifiers=[
+                    {
+                        'id': 'TC-OWNER',
+                        'name': '작성자 시험',
+                        'estimated_minutes': 10,
+                        'owners': ['Alice', 'Bob'],
+                    },
+                ],
+                estimated_minutes=10,
+            )
+
+        r = exec_client.get('/execution/api/list')
+        assert r.status_code == 200
+        item = next(i for i in r.get_json() if i['identifier_id'] == 'TC-OWNER')
+        assert item['owners'] == ['Alice', 'Bob']
+        assert item['assignee_names'] == ['테스트 담당자']
+
     def test_total_count(self, exec_client):
         r = exec_client.get('/execution/api/total-count/TC-001')
         assert r.status_code == 200


### PR DESCRIPTION
## Summary
- expose identifier owners in execution list/item API responses
- rename the execution 담당자 column/search/sidebar label to 작성자
- render/search identifier owners so it matches the scheduling block detail author data

## Validation
- pytest tests/test_execution.py
- pytest

Closes #153